### PR TITLE
Add verified QC35 support

### DIFF
--- a/cpp/src/connection.h
+++ b/cpp/src/connection.h
@@ -71,8 +71,8 @@ public:
     }
 
     DeviceStatus status() {
-        auto idx = mode_idx();
-        auto mode_name = mode_name_from_idx(idx);
+        auto idx = safe_call<uint8_t>([&]{ return mode_idx(); }, 0);
+        auto mode_name = safe_call<std::string>([&]{ return mode_name_from_idx(idx); }, "");
         auto [cnc_cur, cnc_max] = safe_call<std::pair<uint8_t,uint8_t>>(
             [&]{ return cnc(); }, {0, 10});
         auto [prom_on, prom_lang] = safe_call<std::pair<bool,std::string>>(

--- a/cpp/src/device.h
+++ b/cpp/src/device.h
@@ -78,6 +78,8 @@ using ModeConfigParser = std::function<std::optional<ModeConfig>(const std::vect
 
 struct DeviceConfig {
     DeviceInfo info;
+    /// RFCOMM channel for BMAP (2 for newer devices, 8 for QC35).
+    uint8_t rfcomm_channel = 2;
     std::optional<Addr> battery;
     std::optional<Addr> firmware;
     std::optional<Addr> product_name;

--- a/cpp/src/devices.h
+++ b/cpp/src/devices.h
@@ -36,18 +36,20 @@ inline DeviceConfig qc_ultra2() {
     return c;
 }
 
+/// Bose QC35 — verified against firmware 4.8.1. RFCOMM channel 8.
 inline DeviceConfig qc35() {
     DeviceConfig c;
     c.info = {"Bose QuietComfort 35", "baywolf", "CSR8670"};
+    c.rfcomm_channel = 8;
     c.battery = Addr{2, 2};
     c.firmware = Addr{0, 5};
     c.product_name = Addr{1, 2};
     c.voice_prompts = Addr{1, 3};
-    c.cnc = Addr{1, 5};
-    c.multipoint = Addr{1, 10};
-    c.auto_pause = Addr{1, 24};
+    // cnc [3.2] is auth-gated on fw 4.8.1
+    c.sidetone = Addr{1, 11};
+    c.buttons = Addr{1, 9};
     c.pairing = Addr{4, 8};
-    c.power = Addr{7, 4};
+    // No: eq, multipoint, auto_pause, auto_answer, power, AudioModes block 31
     c.preset_modes = {
         {"high", {0, "High — full noise cancellation"}},
         {"low",  {1, "Low — reduced noise cancellation"}},

--- a/cpp/src/main.cpp
+++ b/cpp/src/main.cpp
@@ -65,7 +65,7 @@ int main(int argc, char** argv) {
 
     std::unique_ptr<Transport> transport;
     try {
-        transport = std::make_unique<RfcommTransport>(mac);
+        transport = std::make_unique<RfcommTransport>(mac, config->rfcomm_channel);
     } catch (const std::exception& e) {
         std::cerr << "Connection failed: " << e.what() << "\n"
                   << "Is Bluetooth on? Are the headphones paired and connected?\n";

--- a/python/pybmap/__init__.py
+++ b/python/pybmap/__init__.py
@@ -55,6 +55,7 @@ def connect(mac=None, device_type=None):
         device_type = "qc_ultra2"
 
     device = get_device(device_type)
-    transport = RfcommTransport(mac)
+    channel = getattr(device, "RFCOMM_CHANNEL", 2)
+    transport = RfcommTransport(mac, channel=channel)
     transport.connect()
     return BmapConnection(transport, device)

--- a/python/pybmap/connection.py
+++ b/python/pybmap/connection.py
@@ -219,7 +219,7 @@ class BmapConnection:
     def status(self):
         """Full device status snapshot. Returns DeviceStatus namedtuple."""
         # Single GET for mode index, derive name without extra round trip.
-        current_idx = self.mode_idx()
+        current_idx = self._safe_read(self.mode_idx, None)
         current_name = self._mode_name_from_idx(current_idx) if current_idx is not None else ""
         cnc_cur, cnc_max = self._safe_read(self.cnc, (0, 10))
         prompts_on, prompts_lang = self._safe_read(self.prompts, (False, ""))

--- a/python/pybmap/devices/qc35.py
+++ b/python/pybmap/devices/qc35.py
@@ -1,27 +1,30 @@
 """Bose QC35 / QC35 II device configuration.
 
-Qualcomm CSR8670 platform.
-No ECDH auth — all operators accessible without cloud auth.
+Verified against real QC35 hardware on firmware 4.8.1.
+BMAP over RFCOMM channel 8 (not channel 2 like newer devices).
 
-This is a stub based on known information from based-connect and other
-RE projects. Payload formats and feature availability need verification
-against real hardware.
-
-TODO: Connect QC35 via Bluetooth and verify/complete this config.
+Capabilities verified:
+  - Battery, firmware, serial, product name: GET works
+  - Device name, sidetone, voice prompts: GET + SETGET works
+  - Buttons: GET works (read-only)
+  - Pairing mode: START works
+  - NC level [3.2]: auth-gated on firmware 4.8.1 (was open on 1.x)
+  - No EQ, no spatial audio, no AudioModes block 31, no power off,
+    no multipoint, no auto-pause/answer
 """
 
 from . import parsers
 
+RFCOMM_CHANNEL = 8
+
 DEVICE_INFO = {
     "name": "Bose QuietComfort 35",
-    "codename": "baywolf",  # Verify
+    "codename": "baywolf",
     "platform": "CSR8670",
-    "product_id": None,  # TODO: determine from device
-    "variant": None,
+    "product_id": 0x4020,
+    "variant": 0x02,
 }
 
-# Feature map — addresses based on based-connect and community RE.
-# Many of these need verification on real hardware.
 FEATURES = {
     "battery": {
         "addr": (2, 2),
@@ -34,41 +37,28 @@ FEATURES = {
     "product_name": {
         "addr": (1, 2),
         "parser": parsers.parse_product_name,
+        "builder": lambda name: name.encode("utf-8"),
     },
     "voice_prompts": {
         "addr": (1, 3),
         "parser": parsers.parse_voice_prompts,
         "builder": parsers.build_voice_prompts,
     },
-    # QC35 has 3-level ANC (high/low/off), not a 0-10 CNC slider.
-    # The function block address and payload format may differ.
-    "cnc": {
-        "addr": (1, 5),  # TODO: verify
-        "parser": parsers.parse_cnc,
+    "sidetone": {
+        "addr": (1, 11),
+        "parser": parsers.parse_sidetone,
+        "builder": parsers.build_sidetone,
     },
-    "multipoint": {
-        "addr": (1, 10),  # TODO: verify
-        "parser": parsers.parse_multipoint,
-        "builder": parsers.build_toggle,
-    },
-    "auto_pause": {
-        "addr": (1, 24),  # TODO: verify
-        "parser": parsers.parse_bool,
-        "builder": parsers.build_toggle,
+    "buttons": {
+        "addr": (1, 9),
+        "parser": parsers.parse_buttons,
     },
     "pairing": {
-        "addr": (4, 8),  # TODO: verify
+        "addr": (4, 8),
     },
-    "power": {
-        "addr": (7, 4),  # TODO: verify
-    },
-    # QC35 does NOT have these features:
-    # - eq (no EQ control)
-    # - spatial (no spatial audio)
-    # - sidetone
-    # - auto_answer
-    # - mode_config / AudioModes block 31 (uses different ANC approach)
-    # - buttons (no configurable shortcut button)
+    # NC level at [3.2] is auth-gated on firmware 4.8.1.
+    # based-connect worked on firmware 1.x using SET on [3.2].
+    # START with 14-byte payload is accepted but does not change NC audibly.
 }
 
 PRESET_MODES = {
@@ -79,6 +69,6 @@ PRESET_MODES = {
 
 MODE_BY_IDX = {m["idx"]: name for name, m in PRESET_MODES.items()}
 
-EDITABLE_SLOTS = []  # QC35 has no editable mode slots
+EDITABLE_SLOTS = []
 
-STATUS_OFFSETS = {}  # No mode config on QC35
+STATUS_OFFSETS = {}

--- a/python/pybmap/devices/qc_ultra2.py
+++ b/python/pybmap/devices/qc_ultra2.py
@@ -18,6 +18,8 @@ Auth notes:
 
 from . import parsers
 
+RFCOMM_CHANNEL = 2
+
 # ── Device Identity ──────────────────────────────────────────────────────────
 
 DEVICE_INFO = {

--- a/rust/src/connection.rs
+++ b/rust/src/connection.rs
@@ -196,8 +196,10 @@ impl<T: Transport> BmapConnection<T> {
     /// Full device status.
     pub fn status(&self) -> BmapResult<DeviceStatus> {
         // Single GET for mode index, derive name without extra round trip.
-        let current_idx = self.mode_idx()?;
-        let current_name = self.mode_name_from_idx(current_idx);
+        let (current_idx, current_name) = match self.mode_idx() {
+            Ok(idx) => (idx, self.mode_name_from_idx(idx)),
+            Err(_) => (0, String::new()),
+        };
         let (cnc_level, cnc_max) = self.cnc().unwrap_or((0, 10));
         let (prompts_enabled, prompts_language) = self.prompts().unwrap_or((false, "Unknown"));
 
@@ -714,7 +716,7 @@ mod tests {
         let dev = BmapConnection::new(t, devices::qc35());
         assert!(dev.has_feature("battery"));
         assert!(!dev.has_feature("eq"));
-        assert!(!dev.has_feature("sidetone"));
+        assert!(dev.has_feature("sidetone"));  // QC35 has sidetone
         assert!(!dev.has_feature("mode_config"));
     }
 

--- a/rust/src/device.rs
+++ b/rust/src/device.rs
@@ -82,6 +82,8 @@ pub struct DeviceStatus {
 #[derive(Debug, Clone)]
 pub struct DeviceConfig {
     pub info: DeviceInfo,
+    /// RFCOMM channel for BMAP (2 for newer devices, 8 for QC35).
+    pub rfcomm_channel: u8,
     pub battery: Option<Addr>,
     pub firmware: Option<Addr>,
     pub product_name: Option<Addr>,

--- a/rust/src/devices.rs
+++ b/rust/src/devices.rs
@@ -10,6 +10,7 @@ pub fn qc_ultra2() -> DeviceConfig {
             codename: "wolverine",
             platform: "OTG-QCC-384",
         },
+        rfcomm_channel: 2,
         battery: Some(Addr(2, 2)),
         firmware: Some(Addr(0, 5)),
         product_name: Some(Addr(1, 2)),
@@ -38,7 +39,8 @@ pub fn qc_ultra2() -> DeviceConfig {
     }
 }
 
-/// Bose QC35 configuration (stub — needs hardware verification).
+/// Bose QC35 configuration — verified against firmware 4.8.1.
+/// BMAP over RFCOMM channel 8.
 pub fn qc35() -> DeviceConfig {
     DeviceConfig {
         info: DeviceInfo {
@@ -46,19 +48,20 @@ pub fn qc35() -> DeviceConfig {
             codename: "baywolf",
             platform: "CSR8670",
         },
+        rfcomm_channel: 8,
         battery: Some(Addr(2, 2)),
         firmware: Some(Addr(0, 5)),
         product_name: Some(Addr(1, 2)),
         voice_prompts: Some(Addr(1, 3)),
-        cnc: Some(Addr(1, 5)),
+        cnc: None, // [3.2] auth-gated on fw 4.8.1
         eq: None,
-        buttons: None,
-        multipoint: Some(Addr(1, 10)),
-        sidetone: None,
-        auto_pause: Some(Addr(1, 24)),
+        buttons: Some(Addr(1, 9)),
+        multipoint: None, // [1.10] not supported
+        sidetone: Some(Addr(1, 11)),
+        auto_pause: None, // [1.24] not supported
         auto_answer: None,
         pairing: Some(Addr(4, 8)),
-        power: Some(Addr(7, 4)),
+        power: None, // block 7 not supported
         get_all_modes: None,
         current_mode: None,
         mode_config: None,

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -40,6 +40,6 @@ pub fn connect(mac: Option<&str>, device_type: &str) -> BmapResult<BmapConnectio
     let config = devices::get_device(device_type)
         .ok_or_else(|| BmapError::InvalidArg(format!("Unknown device: {}", device_type)))?;
 
-    let transport = transport::RfcommTransport::connect(&mac, transport::BMAP_CHANNEL)?;
+    let transport = transport::RfcommTransport::connect(&mac, config.rfcomm_channel)?;
     Ok(BmapConnection::new(transport, config))
 }


### PR DESCRIPTION
## Summary

- Probed real QC35 hardware (fw 4.8.1) and updated device configs in all three languages
- Added per-device RFCOMM channel support (QC35 uses channel 8, Ultra 2 uses channel 2)
- Fixed `status()` crash on devices without `current_mode` (block 31 not present on QC35)
- Removed unverified features from QC35 config (cnc, multipoint, auto_pause, power were all non-functional)
- Added verified features: sidetone and buttons (both confirmed working on real hardware)

## Verified against real QC35

```
$ BMAP_MAC=4C:87:5D:08:0B:17 BMAP_DEVICE=qc35 ./bosectl status
  Battery      60%
  Mode         
  CNC          ░░░░░░░░░░ 0/10
  Name         Aluminum Mistress
  FW           4.8.1
  Sidetone     medium
  Multipoint   off
  AutoPause    off
  Prompts      on (US English)
```

## Test plan

- [x] `make test` — 181 tests pass (91 Python + 48 Rust + 42 C++)
- [x] `bosectl status` with BMAP_DEVICE=qc35 against real QC35
- [x] QC Ultra 2 still works (channel 2 preserved)