### PR TITLE
Make all three languages fully consistent

### DIFF
--- a/cpp/src/connection.h
+++ b/cpp/src/connection.h
@@ -99,7 +99,7 @@ public:
     // ── Write Operations ────────────────────────────────────────────────────
 
     void set_mode(const std::string& name, bool announce = false) {
-        auto addr = *config_.current_mode;
+        auto addr = require(config_.current_mode, "current_mode");
         uint8_t idx = 255;
         for (auto& [n, m] : config_.preset_modes) {
             if (n == name) { idx = m.idx; break; }
@@ -114,8 +114,28 @@ public:
         start(addr, {idx, static_cast<uint8_t>(announce ? 1 : 0)});
     }
 
+    void set_cnc(uint8_t level) {
+        if (level > 10) throw std::runtime_error("CNC level must be 0-10");
+        auto [slot, config] = ensure_editable_profile();
+        config.cnc_level = level;
+        write_mode(slot, config);
+        start(require(config_.current_mode, "current_mode"), {slot, 0});
+    }
+
+    void set_spatial(const std::string& mode) {
+        uint8_t val;
+        if (mode == "off") val = 0;
+        else if (mode == "room") val = 1;
+        else if (mode == "head") val = 2;
+        else throw std::runtime_error("Spatial: off, room, head");
+        auto [slot, config] = ensure_editable_profile();
+        config.spatial = val;
+        write_mode(slot, config);
+        start(require(config_.current_mode, "current_mode"), {slot, 0});
+    }
+
     void set_eq(int8_t bass, int8_t mid, int8_t treble) {
-        auto addr = *config_.eq;
+        auto addr = require(config_.eq, "eq");
         for (auto [band_id, val] : std::vector<std::pair<uint8_t,int8_t>>{{0,bass},{1,mid},{2,treble}}) {
             transport_->send_recv(bmap_packet(addr.fblock, addr.func, Operator::SetGet,
                                               {static_cast<uint8_t>(val), band_id}));
@@ -135,6 +155,10 @@ public:
         setget(require(config_.auto_pause, "auto_pause"), {static_cast<uint8_t>(on ? 1 : 0)});
     }
 
+    void set_auto_answer(bool on) {
+        setget(require(config_.auto_answer, "auto_answer"), {static_cast<uint8_t>(on ? 1 : 0)});
+    }
+
     void set_anr(const std::string& level) {
         uint8_t val;
         if (level == "off") val = 0;
@@ -143,6 +167,14 @@ public:
         else if (level == "low") val = 3;
         else throw std::runtime_error("ANR: off, high, wind, low");
         setget(require(config_.anr, "anr"), {val});
+    }
+
+    void set_prompts(bool enabled) {
+        auto addr = require(config_.voice_prompts, "voice_prompts");
+        auto payload = get(addr);
+        uint8_t lang = payload.empty() ? 0 : (payload[0] & 0x1F);
+        uint8_t byte0 = ((enabled ? 1 : 0) << 5) | lang;
+        setget(addr, {byte0});
     }
 
     void set_sidetone(const std::string& level) {
@@ -157,6 +189,38 @@ public:
 
     void power_off() { start(require(config_.power, "power"), {0x00}); }
     void pair()      { start(require(config_.pairing, "pairing"), {0x01}); }
+
+    // ── Profile Management ──────────────────────────────────────────────────
+
+    uint8_t create_profile(const std::string& name, uint8_t cnc = 0, uint8_t spatial = 0,
+                           bool wind = true, bool anc = true) {
+        auto all = modes();
+        auto slot = find_free_slot(all);
+        ModeConfig mc{};
+        mc.mode_idx = slot;
+        mc.name = name;
+        mc.cnc_level = cnc;
+        mc.spatial = spatial;
+        mc.wind_block = wind;
+        mc.anc_toggle = anc;
+        write_mode(slot, mc);
+        return slot;
+    }
+
+    void delete_profile(const std::string& name) {
+        auto all = modes();
+        for (auto& m : all) {
+            if (m.name == name) {
+                if (!m.editable) throw std::runtime_error("Cannot delete preset: " + name);
+                ModeConfig mc{};
+                mc.mode_idx = m.mode_idx;
+                mc.name = "None";
+                write_mode(m.mode_idx, mc);
+                return;
+            }
+        }
+        throw std::runtime_error("Profile not found: " + name);
+    }
 
     std::vector<BmapResponse> send_raw(const std::vector<uint8_t>& data) {
         auto resp = transport_->send_recv_drain(data);
@@ -225,6 +289,59 @@ private:
     template<typename T, typename F>
     T safe_call(F fn, T default_val) {
         try { return fn(); } catch (...) { return default_val; }
+    }
+
+    std::pair<uint8_t, ModeConfig> ensure_editable_profile() {
+        auto all = modes();
+        auto idx = safe_call<uint8_t>([&]{ return mode_idx(); }, 0);
+        for (auto& m : all) {
+            if (m.mode_idx == idx && m.editable) return {idx, m};
+        }
+        // Look for existing "Custom" profile
+        for (auto& m : all) {
+            if (m.name == "Custom" && m.editable) return {m.mode_idx, m};
+        }
+        // Create one
+        auto slot = find_free_slot(all);
+        auto [cnc_cur, _] = safe_call<std::pair<uint8_t,uint8_t>>(
+            [&]{ return cnc(); }, {0, 10});
+        ModeConfig mc{};
+        mc.mode_idx = slot;
+        mc.name = "Custom";
+        mc.cnc_level = cnc_cur;
+        mc.wind_block = true;
+        mc.anc_toggle = true;
+        write_mode(slot, mc);
+        return {slot, mc};
+    }
+
+    uint8_t find_free_slot(const std::vector<ModeConfig>& all) {
+        for (auto slot : config_.editable_slots) {
+            bool found = false;
+            for (auto& m : all) {
+                if (m.mode_idx == slot && m.configured && m.name != "None") {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) return slot;
+        }
+        throw std::runtime_error("No free profile slot available");
+    }
+
+    void write_mode(uint8_t slot, const ModeConfig& mc) {
+        auto addr = require(config_.mode_config, "mode_config");
+        auto payload = build_mode_config_40(
+            slot, mc.name, mc.cnc_level, mc.spatial,
+            mc.wind_block, mc.anc_toggle, mc.prompt_b1, mc.prompt_b2);
+        auto pkt = bmap_packet(addr.fblock, addr.func, Operator::SetGet, payload);
+        auto data = transport_->send_recv_drain(pkt);
+        auto responses = parse_all_responses(data);
+        bool ok = false;
+        for (auto& r : responses) {
+            if (r.op == Operator::Status) { ok = true; break; }
+        }
+        if (!ok) throw std::runtime_error("Mode config write failed");
     }
 };
 

--- a/cpp/src/main.cpp
+++ b/cpp/src/main.cpp
@@ -77,13 +77,17 @@ int main(int argc, char** argv) {
     try {
         if (cmd == "status") {
             auto s = dev.status();
-            std::string bar;
-            for (int i = 0; i < s.cnc_level; i++) bar += "\xe2\x96\x88";
-            for (int i = s.cnc_level; i < s.cnc_max; i++) bar += "\xe2\x96\x91";
-
-            std::cout << "  Battery      " << (int)s.battery << "%\n"
-                      << "  Mode         " << s.mode << "\n"
-                      << "  CNC          " << bar << " " << (int)s.cnc_level << "/" << (int)s.cnc_max << "\n";
+            std::cout << "  Battery      " << (int)s.battery << "%\n";
+            if (!s.mode.empty())
+                std::cout << "  Mode         " << s.mode << "\n";
+            if (dev.has_feature("anr")) {
+                try { std::cout << "  ANR          " << dev.anr() << "\n"; } catch (...) {}
+            } else if (dev.has_feature("cnc")) {
+                std::string bar;
+                for (int i = 0; i < s.cnc_level; i++) bar += "\xe2\x96\x88";
+                for (int i = s.cnc_level; i < s.cnc_max; i++) bar += "\xe2\x96\x91";
+                std::cout << "  CNC          " << bar << " " << (int)s.cnc_level << "/" << (int)s.cnc_max << "\n";
+            }
             if (!s.eq.empty()) {
                 std::cout << "  EQ           ";
                 for (size_t i = 0; i < s.eq.size(); i++) {
@@ -109,14 +113,25 @@ int main(int argc, char** argv) {
         } else if (cmd == "quiet" || cmd == "aware" || cmd == "immersion" || cmd == "cinema") {
             dev.set_mode(cmd);
             std::cout << "OK: " << cmd << "\n";
+        } else if (cmd == "switch") {
+            if (argc < 3) { std::cerr << "Usage: bmapctl switch <name>\n"; return 1; }
+            dev.set_mode(argv[2]);
+            std::cout << "OK: " << argv[2] << "\n";
         } else if (cmd == "cnc") {
             if (argc > 2) {
-                // set_cnc not implemented yet in C++ CLI
-                std::cerr << "CNC set not yet implemented in C++ CLI\n";
+                dev.set_cnc(std::atoi(argv[2]));
+                std::cout << "CNC: " << argv[2] << "/10\n";
             } else {
                 auto [cur, max] = dev.cnc();
                 std::cout << (int)cur << "/" << (int)max << "\n";
             }
+        } else if (cmd == "anr") {
+            if (argc > 2) dev.set_anr(argv[2]);
+            std::cout << dev.anr() << "\n";
+        } else if (cmd == "spatial") {
+            if (argc < 3) { std::cerr << "Usage: bmapctl spatial <off|room|head>\n"; return 1; }
+            dev.set_spatial(argv[2]);
+            std::cout << "Spatial: " << argv[2] << "\n";
         } else if (cmd == "eq") {
             if (argc >= 5) {
                 dev.set_eq(std::atoi(argv[2]), std::atoi(argv[3]), std::atoi(argv[4]));
@@ -146,7 +161,11 @@ int main(int argc, char** argv) {
         } else if (cmd == "autopause") {
             if (argc > 2) dev.set_auto_pause(is_on(argv[2]));
             std::cout << (dev.auto_pause() ? "on" : "off") << "\n";
+        } else if (cmd == "autoanswer") {
+            if (argc > 2) dev.set_auto_answer(is_on(argv[2]));
+            std::cout << (dev.auto_answer() ? "on" : "off") << "\n";
         } else if (cmd == "prompts") {
+            if (argc > 2) dev.set_prompts(is_on(argv[2]));
             auto [on, lang] = dev.prompts();
             std::cout << (on ? "on" : "off") << " (" << lang << ")\n";
         } else if (cmd == "buttons") {
@@ -157,15 +176,47 @@ int main(int argc, char** argv) {
                           << "Event:   " << btn->event_name << "\n"
                           << "Action:  " << btn->action_name << "\n";
             }
+        } else if (cmd == "profiles") {
+            auto all = dev.modes();
+            for (auto& m : all) {
+                std::cout << "  " << (int)m.mode_idx << "  " << m.name;
+                if (!m.editable) std::cout << " [preset]";
+                else if (!m.configured) std::cout << " [empty]";
+                std::cout << "\n";
+            }
         } else if (cmd == "pair") {
             dev.pair();
             std::cout << "Pairing mode enabled\n";
         } else if (cmd == "off") {
             dev.power_off();
             std::cout << "Powering off\n";
+        } else if (cmd == "dump") {
+            auto pkt = bmap_packet(31, 1, Operator::Start);
+            for (auto& r : dev.send_raw(pkt)) {
+                std::cout << r.fmt() << "\n";
+            }
+        } else if (cmd == "raw") {
+            if (argc < 3) { std::cerr << "Usage: bmapctl raw <hex>\n"; return 1; }
+            std::string hex;
+            for (int i = 2; i < argc; i++) hex += argv[i];
+            // Parse hex to bytes
+            std::vector<uint8_t> data;
+            for (size_t i = 0; i + 1 < hex.size(); i += 2) {
+                data.push_back(static_cast<uint8_t>(std::stoi(hex.substr(i, 2), nullptr, 16)));
+            }
+            std::cout << "TX: " << hex << "\n";
+            for (auto& r : dev.send_raw(data)) {
+                std::cout << "RX: " << r.fmt() << "\n";
+            }
         } else {
-            std::cerr << "Unknown command: " << cmd << "\n";
-            return 1;
+            // Try as custom profile name
+            try {
+                dev.set_mode(cmd);
+                std::cout << "OK: " << cmd << "\n";
+            } catch (...) {
+                std::cerr << "Unknown command: " << cmd << "\n";
+                return 1;
+            }
         }
     } catch (const std::exception& e) {
         std::cerr << "Error: " << e.what() << "\n";

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -122,14 +122,46 @@ fn main() {
             }
             dev.auto_pause().map(|a| println!("{}", if a { "on" } else { "off" }))
         }
-        "prompts" => dev.prompts().map(|(on, lang)| {
-            println!("{} ({})", if on { "on" } else { "off" }, lang);
-        }),
+        "anr" => {
+            if args.len() > 2 {
+                if let Err(e) = dev.set_anr(&args[2]) {
+                    return err_exit(&e);
+                }
+            }
+            dev.anr().map(|a| println!("{}", a))
+        }
+        "prompts" => {
+            if args.len() > 2 {
+                let on = matches!(args[2].as_str(), "on" | "1" | "true" | "yes");
+                if let Err(e) = dev.set_prompts(on) {
+                    return err_exit(&e);
+                }
+            }
+            dev.prompts().map(|(on, lang)| {
+                println!("{} ({})", if on { "on" } else { "off" }, lang);
+            })
+        }
         "buttons" => dev.buttons().map(|btn| {
             println!("Button:  {} (0x{:02x})", btn.button_name, btn.button_id);
             println!("Event:   {}", btn.event_name);
             println!("Action:  {}", btn.action_name);
         }),
+        "profiles" => dev.modes().map(|modes| {
+            for m in &modes {
+                print!("  {:2}  {}", m.mode_idx, m.name);
+                if !m.editable { print!(" [preset]"); }
+                else if !m.configured { print!(" [empty]"); }
+                println!();
+            }
+        }),
+        "dump" => {
+            let pkt = bmap::protocol::bmap_packet(31, 1, bmap::Operator::Start, &[]);
+            dev.send_raw(&pkt).map(|responses| {
+                for r in &responses {
+                    println!("{}", r.fmt());
+                }
+            })
+        }
         "pair" => dev.pair().map(|_| println!("Pairing mode enabled")),
         "off" => dev.power_off().map(|_| println!("Powering off")),
         "raw" => {
@@ -147,8 +179,14 @@ fn main() {
             })
         }
         _ => {
-            eprintln!("Unknown command: {}", cmd);
-            process::exit(1);
+            // Try as custom profile name
+            match dev.set_mode(&cmd, false) {
+                Ok(_) => Ok(println!("OK: {}", cmd)),
+                Err(_) => {
+                    eprintln!("Unknown command: {}", cmd);
+                    process::exit(1);
+                }
+            }
         }
     };
 
@@ -169,8 +207,16 @@ fn cmd_status(dev: &bmap::BmapConnection<impl bmap::Transport>) -> Result<(), Bm
         + &"░".repeat((s.cnc_max - s.cnc_level) as usize);
 
     println!("  Battery      {}%", s.battery);
-    println!("  Mode         {}", s.mode);
-    println!("  CNC          {} {}/{}", cnc_bar, s.cnc_level, s.cnc_max);
+    if !s.mode.is_empty() {
+        println!("  Mode         {}", s.mode);
+    }
+    if dev.anr().is_ok() {
+        if let Ok(anr) = dev.anr() {
+            println!("  ANR          {}", anr);
+        }
+    } else {
+        println!("  CNC          {} {}/{}", cnc_bar, s.cnc_level, s.cnc_max);
+    }
     if !s.eq.is_empty() {
         let eq_str: Vec<String> = s.eq.iter().map(|b| format!("{:+}", b.current)).collect();
         println!("  EQ           {} (bass/mid/treble)", eq_str.join("/"));


### PR DESCRIPTION
## Summary

Closes the gap between Python (reference), Rust, and C++ implementations.

**C++ library** — added 8 missing methods:
- `set_cnc()`, `set_spatial()`, `set_auto_answer()`, `set_prompts()`
- `create_profile()`, `delete_profile()` + internal `ensure_editable_profile()`, `write_mode()`

**C++ CLI** — added 9 missing commands:
- `anr`, `spatial`, `switch`, `autoanswer`, `profiles`, `dump`, `raw`
- `cnc` and `prompts` now support write (were read-only)

**Rust CLI** — added 4 missing commands:
- `anr`, `profiles`, `dump`, `prompts` set

**All three** — adaptive status display (ANR for QC35, CNC for Ultra 2)

## Test plan

- [x] `make test` — 181 tests pass (91 Python + 48 Rust + 42 C++)
- [x] All three CLIs now support the same 20+ commands
- [x] Status display adapts to device capabilities