### PR TITLE
Smart auto-discovery and init packet across all languages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@ build/
 linkedin-article.md
 article-techy.md
 target/
-apk-analysis/

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,4 @@ build/
 .eggs/
 .venv/
 .pytest_cache/
-linkedin-article.md
-article-techy.md
 target/

--- a/cpp/src/bmap.h
+++ b/cpp/src/bmap.h
@@ -8,3 +8,47 @@
 #include "devices.h"
 #include "connection.h"
 #include "discovery.h"
+
+namespace bmap {
+
+/// Connect to a BMAP device, auto-detecting if mac/device_type are empty.
+inline std::unique_ptr<BmapConnection> connect(
+    const std::string& mac_override = "",
+    const std::string& device_type_override = "")
+{
+    std::string mac = mac_override;
+    std::string device_type = device_type_override;
+
+    if (mac.empty()) {
+        auto detected = find_bmap_device();
+        if (!detected) {
+            throw std::runtime_error(
+                "No connected BMAP device found. Pair and connect via bluetoothctl or pass --mac");
+        }
+        mac = detected->first;
+        if (device_type.empty()) {
+            device_type = detected->second;
+        }
+    }
+    if (device_type.empty()) {
+        device_type = "qc_ultra2";
+    }
+
+    auto config = get_device(device_type);
+    if (!config) {
+        throw std::runtime_error("Unknown device type: " + device_type);
+    }
+
+    auto transport = std::make_unique<RfcommTransport>(mac, config->rfcomm_channel);
+
+    // Some devices require an init packet before responding.
+    if (config->init_packet) {
+        auto pkt = bmap_packet(config->init_packet->fblock,
+                               config->init_packet->func, Operator::Get);
+        transport->send_recv(pkt);
+    }
+
+    return std::make_unique<BmapConnection>(std::move(transport), std::move(*config));
+}
+
+} // namespace bmap

--- a/cpp/src/device.h
+++ b/cpp/src/device.h
@@ -80,6 +80,8 @@ struct DeviceConfig {
     DeviceInfo info;
     /// RFCOMM channel for BMAP (2 for newer devices, 8 for QC35).
     uint8_t rfcomm_channel = 2;
+    /// Init packet required before device responds (QC35 needs GET [0.1]).
+    std::optional<Addr> init_packet;
     std::optional<Addr> battery;
     std::optional<Addr> firmware;
     std::optional<Addr> product_name;

--- a/cpp/src/devices.h
+++ b/cpp/src/devices.h
@@ -41,6 +41,7 @@ inline DeviceConfig qc35() {
     DeviceConfig c;
     c.info = {"Bose QuietComfort 35", "baywolf", "CSR8670"};
     c.rfcomm_channel = 8;
+    c.init_packet = Addr{0, 1};  // GET [0.1] required before QC35 responds
     c.battery = Addr{2, 2};
     c.firmware = Addr{0, 5};
     c.product_name = Addr{1, 2};

--- a/cpp/src/discovery.cpp
+++ b/cpp/src/discovery.cpp
@@ -4,15 +4,19 @@
 #include <array>
 #include <cstdio>
 #include <memory>
+#include <regex>
 #include <sstream>
 #include <string>
+#include <vector>
 
 namespace bmap {
+
+static const char* BMAP_UUID = "00000000-deca-fade-deca-deafdecacaff";
 
 static std::string exec(const std::string& cmd) {
     std::array<char, 256> buf;
     std::string result;
-    std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(cmd.c_str(), "r"), pclose);
+    std::unique_ptr<FILE, int(*)(FILE*)> pipe(popen(cmd.c_str(), "r"), pclose);
     if (!pipe) return "";
     while (fgets(buf.data(), buf.size(), pipe.get())) {
         result += buf.data();
@@ -20,13 +24,26 @@ static std::string exec(const std::string& cmd) {
     return result;
 }
 
-std::optional<std::string> find_bmap_device() {
+static std::string detect_device_type(const std::string& info) {
+    std::regex modalias_re(R"(Modalias:\s*bluetooth:v[0-9A-Fa-f]{4}p([0-9A-Fa-f]{4}))");
+    std::smatch match;
+    if (std::regex_search(info, match, modalias_re)) {
+        unsigned int product_id = std::stoul(match[1].str(), nullptr, 16);
+        if (product_id == 0x4082) return "qc_ultra2";
+        if (product_id == 0x4020 || product_id == 0x400C) return "qc35";
+    }
+    return "qc_ultra2";
+}
+
+std::optional<std::pair<std::string, std::string>> find_bmap_device() {
     auto output = exec("bluetoothctl devices Paired 2>/dev/null");
     std::istringstream stream(output);
     std::string line;
 
+    struct Candidate { std::string mac; std::string device_type; bool connected; };
+    std::vector<Candidate> candidates;
+
     while (std::getline(stream, line)) {
-        // Line format: "Device AA:BB:CC:DD:EE:FF Name"
         auto first_space = line.find(' ');
         if (first_space == std::string::npos) continue;
         auto second_space = line.find(' ', first_space + 1);
@@ -34,16 +51,22 @@ std::optional<std::string> find_bmap_device() {
         auto mac = line.substr(first_space + 1, second_space - first_space - 1);
 
         auto info = exec("bluetoothctl info " + mac + " 2>/dev/null");
-        if (info.find("Icon: audio-headset") != std::string::npos &&
-            info.find("00000000-deca-fade-deca-deafdecacaff") != std::string::npos) {
-            return mac;
-        }
-        // Fallback: name matching
-        std::string lower_info = info;
-        for (auto& c : lower_info) c = std::tolower(c);
-        if (lower_info.find("bose") != std::string::npos) {
-            return mac;
-        }
+
+        bool is_audio = (info.find("audio-headset") != std::string::npos ||
+                         info.find("audio-headphones") != std::string::npos);
+        bool has_bmap = info.find(BMAP_UUID) != std::string::npos;
+        if (!(is_audio && has_bmap)) continue;
+
+        bool connected = info.find("Connected: yes") != std::string::npos;
+        candidates.push_back({mac, detect_device_type(info), connected});
+    }
+
+    // Prefer connected devices
+    for (auto& c : candidates) {
+        if (c.connected) return std::make_pair(c.mac, c.device_type);
+    }
+    if (!candidates.empty()) {
+        return std::make_pair(candidates[0].mac, candidates[0].device_type);
     }
     return std::nullopt;
 }

--- a/cpp/src/discovery.h
+++ b/cpp/src/discovery.h
@@ -3,9 +3,12 @@
 
 #include <optional>
 #include <string>
+#include <utility>
 
 namespace bmap {
 
-std::optional<std::string> find_bmap_device();
+/// Auto-detect a paired, connected BMAP device.
+/// Returns (mac, device_type) or nullopt.
+std::optional<std::pair<std::string, std::string>> find_bmap_device();
 
 } // namespace bmap

--- a/cpp/src/main.cpp
+++ b/cpp/src/main.cpp
@@ -40,21 +40,24 @@ int main(int argc, char** argv) {
     std::string cmd = argv[1];
     if (cmd == "help" || cmd == "-h" || cmd == "--help") { usage(); return 0; }
 
-    // Resolve MAC and device type
+    // Resolve MAC and device type (auto-detect if not set)
     const char* mac_env = std::getenv("BMAP_MAC");
     const char* dev_env = std::getenv("BMAP_DEVICE");
-    std::string device_type = dev_env ? dev_env : "qc_ultra2";
 
     std::string mac;
+    std::string device_type;
+
     if (mac_env) {
         mac = mac_env;
+        device_type = dev_env ? dev_env : "qc_ultra2";
     } else {
         auto detected = find_bmap_device();
         if (!detected) {
-            std::cerr << "No BMAP device found. Set BMAP_MAC or pair via bluetoothctl.\n";
+            std::cerr << "No connected BMAP device found. Set BMAP_MAC or pair via bluetoothctl.\n";
             return 1;
         }
-        mac = *detected;
+        mac = detected->first;
+        device_type = dev_env ? dev_env : detected->second;
     }
 
     auto config = get_device(device_type);
@@ -66,6 +69,11 @@ int main(int argc, char** argv) {
     std::unique_ptr<Transport> transport;
     try {
         transport = std::make_unique<RfcommTransport>(mac, config->rfcomm_channel);
+        // Some devices require an init packet before responding.
+        if (config->init_packet) {
+            auto pkt = bmap_packet(config->init_packet->fblock, config->init_packet->func, Operator::Get);
+            transport->send_recv(pkt);
+        }
     } catch (const std::exception& e) {
         std::cerr << "Connection failed: " << e.what() << "\n"
                   << "Is Bluetooth on? Are the headphones paired and connected?\n";

--- a/cpp/src/main.cpp
+++ b/cpp/src/main.cpp
@@ -40,47 +40,20 @@ int main(int argc, char** argv) {
     std::string cmd = argv[1];
     if (cmd == "help" || cmd == "-h" || cmd == "--help") { usage(); return 0; }
 
-    // Resolve MAC and device type (auto-detect if not set)
     const char* mac_env = std::getenv("BMAP_MAC");
     const char* dev_env = std::getenv("BMAP_DEVICE");
+    std::string mac_str = mac_env ? mac_env : "";
+    std::string dev_str = dev_env ? dev_env : "";
 
-    std::string mac;
-    std::string device_type;
-
-    if (mac_env) {
-        mac = mac_env;
-        device_type = dev_env ? dev_env : "qc_ultra2";
-    } else {
-        auto detected = find_bmap_device();
-        if (!detected) {
-            std::cerr << "No connected BMAP device found. Set BMAP_MAC or pair via bluetoothctl.\n";
-            return 1;
-        }
-        mac = detected->first;
-        device_type = dev_env ? dev_env : detected->second;
-    }
-
-    auto config = get_device(device_type);
-    if (!config) {
-        std::cerr << "Unknown device type: " << device_type << "\n";
-        return 1;
-    }
-
-    std::unique_ptr<Transport> transport;
+    std::unique_ptr<BmapConnection> devptr;
     try {
-        transport = std::make_unique<RfcommTransport>(mac, config->rfcomm_channel);
-        // Some devices require an init packet before responding.
-        if (config->init_packet) {
-            auto pkt = bmap_packet(config->init_packet->fblock, config->init_packet->func, Operator::Get);
-            transport->send_recv(pkt);
-        }
+        devptr = connect(mac_str, dev_str);
     } catch (const std::exception& e) {
         std::cerr << "Connection failed: " << e.what() << "\n"
                   << "Is Bluetooth on? Are the headphones paired and connected?\n";
         return 1;
     }
-
-    BmapConnection dev(std::move(transport), std::move(*config));
+    auto& dev = *devptr;
 
     try {
         if (cmd == "status") {

--- a/rust/src/device.rs
+++ b/rust/src/device.rs
@@ -84,6 +84,8 @@ pub struct DeviceConfig {
     pub info: DeviceInfo,
     /// RFCOMM channel for BMAP (2 for newer devices, 8 for QC35).
     pub rfcomm_channel: u8,
+    /// Init packet required before device responds (Some((fblock, func)) for QC35).
+    pub init_packet: Option<Addr>,
     pub battery: Option<Addr>,
     pub firmware: Option<Addr>,
     pub product_name: Option<Addr>,

--- a/rust/src/devices.rs
+++ b/rust/src/devices.rs
@@ -11,6 +11,7 @@ pub fn qc_ultra2() -> DeviceConfig {
             platform: "OTG-QCC-384",
         },
         rfcomm_channel: 2,
+        init_packet: None,
         battery: Some(Addr(2, 2)),
         firmware: Some(Addr(0, 5)),
         product_name: Some(Addr(1, 2)),
@@ -22,7 +23,7 @@ pub fn qc_ultra2() -> DeviceConfig {
         sidetone: Some(Addr(1, 11)),
         auto_pause: Some(Addr(1, 24)),
         auto_answer: Some(Addr(1, 27)),
-        anr: None,  // Ultra 2 uses CNC, not ANR
+        anr: None,
         pairing: Some(Addr(4, 8)),
         power: Some(Addr(7, 4)),
         get_all_modes: Some(Addr(31, 1)),
@@ -50,11 +51,12 @@ pub fn qc35() -> DeviceConfig {
             platform: "CSR8670",
         },
         rfcomm_channel: 8,
+        init_packet: Some(Addr(0, 1)),  // GET [0.1] required before QC35 responds
         battery: Some(Addr(2, 2)),
         firmware: Some(Addr(0, 5)),
         product_name: Some(Addr(1, 2)),
         voice_prompts: Some(Addr(1, 3)),
-        cnc: None, // [3.2] auth-gated on fw 4.8.1
+        cnc: None,
         eq: None,
         buttons: Some(Addr(1, 9)),
         multipoint: None, // [1.10] not supported

--- a/rust/src/discovery.rs
+++ b/rust/src/discovery.rs
@@ -5,38 +5,91 @@ use std::process::Command;
 /// BMAP service UUID found in SDP records.
 pub const BMAP_UUID: &str = "00000000-deca-fade-deca-deafdecacaff";
 
-/// Auto-detect a paired BMAP-capable Bluetooth device.
+/// A discovered BMAP device.
+#[derive(Debug, Clone)]
+pub struct DiscoveredDevice {
+    pub mac: String,
+    pub device_type: String,
+    pub connected: bool,
+}
+
+/// Auto-detect a paired, connected BMAP-capable Bluetooth device.
 ///
-/// Returns the MAC address string, or None if not found.
-pub fn find_bmap_device() -> Option<String> {
-    let output = Command::new("bluetoothctl")
+/// Prioritizes connected devices. Returns (mac, device_type), or None.
+pub fn find_bmap_device() -> Option<(String, String)> {
+    let candidates = scan_paired_devices();
+
+    // Prefer connected
+    for d in &candidates {
+        if d.connected {
+            return Some((d.mac.clone(), d.device_type.clone()));
+        }
+    }
+    // Fall back to first paired
+    candidates.first().map(|d| (d.mac.clone(), d.device_type.clone()))
+}
+
+/// Scan all paired Bluetooth devices for BMAP-capable headphones.
+pub fn scan_paired_devices() -> Vec<DiscoveredDevice> {
+    let mut candidates = Vec::new();
+    let output = match Command::new("bluetoothctl")
         .args(["devices", "Paired"])
         .output()
-        .ok()?;
+    {
+        Ok(o) => String::from_utf8_lossy(&o.stdout).into_owned(),
+        Err(_) => return candidates,
+    };
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    for line in stdout.lines() {
+    for line in output.lines() {
         let parts: Vec<&str> = line.splitn(3, ' ').collect();
         if parts.len() < 2 {
             continue;
         }
         let mac = parts[1];
 
-        let info = Command::new("bluetoothctl")
+        let info = match Command::new("bluetoothctl")
             .args(["info", mac])
             .output()
-            .ok()?;
-        let info_str = String::from_utf8_lossy(&info.stdout);
+        {
+            Ok(o) => String::from_utf8_lossy(&o.stdout).into_owned(),
+            Err(_) => continue,
+        };
 
-        for info_line in info_str.lines() {
-            let trimmed = info_line.trim();
-            if trimmed.starts_with("Icon: audio-headset") && info_str.contains(BMAP_UUID) {
-                return Some(mac.to_string());
-            }
-            if trimmed.to_lowercase().contains("bose") {
-                return Some(mac.to_string());
+        let is_audio = info.contains("audio-headset") || info.contains("audio-headphones");
+        let has_bmap = info.contains(BMAP_UUID);
+        if !(is_audio && has_bmap) {
+            continue;
+        }
+
+        let connected = info.contains("Connected: yes");
+        let device_type = detect_device_type(&info);
+
+        candidates.push(DiscoveredDevice {
+            mac: mac.to_string(),
+            device_type,
+            connected,
+        });
+    }
+    candidates
+}
+
+/// Detect device type from Modalias product ID.
+fn detect_device_type(info: &str) -> String {
+    // Modalias format: bluetooth:vXXXXpYYYYdZZZZ
+    for line in info.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("Modalias:") {
+            if let Some(p_pos) = trimmed.find('p') {
+                let id_str = &trimmed[p_pos + 1..p_pos + 5];
+                if let Ok(product_id) = u16::from_str_radix(id_str, 16) {
+                    return match product_id {
+                        0x4082 => "qc_ultra2".to_string(),
+                        0x4020 | 0x400C => "qc35".to_string(),
+                        _ => "qc_ultra2".to_string(),
+                    };
+                }
             }
         }
     }
-    None
+    "qc_ultra2".to_string()
 }

--- a/rust/src/discovery.rs
+++ b/rust/src/discovery.rs
@@ -78,15 +78,22 @@ fn detect_device_type(info: &str) -> String {
     // Modalias format: bluetooth:vXXXXpYYYYdZZZZ
     for line in info.lines() {
         let trimmed = line.trim();
-        if trimmed.starts_with("Modalias:") {
-            if let Some(p_pos) = trimmed.find('p') {
-                let id_str = &trimmed[p_pos + 1..p_pos + 5];
-                if let Ok(product_id) = u16::from_str_radix(id_str, 16) {
-                    return match product_id {
-                        0x4082 => "qc_ultra2".to_string(),
-                        0x4020 | 0x400C => "qc35".to_string(),
-                        _ => "qc_ultra2".to_string(),
-                    };
+        if let Some(rest) = trimmed.strip_prefix("Modalias:") {
+            let rest = rest.trim();
+            // Match "bluetooth:vXXXXpYYYYdZZZZ" and extract YYYY
+            if let Some(bt_rest) = rest.strip_prefix("bluetooth:v") {
+                if bt_rest.len() >= 9 {  // "XXXXpYYYY" minimum
+                    let after_vendor = &bt_rest[4..];  // skip vendor "XXXX"
+                    if after_vendor.starts_with('p') {
+                        let id_str = &after_vendor[1..5];
+                        if let Ok(product_id) = u16::from_str_radix(id_str, 16) {
+                            return match product_id {
+                                0x4082 => "qc_ultra2".to_string(),
+                                0x4020 | 0x400C => "qc35".to_string(),
+                                _ => "qc_ultra2".to_string(),
+                            };
+                        }
+                    }
                 }
             }
         }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -3,9 +3,10 @@
 //! # Example
 //!
 //! ```no_run
-//! use bmap::{connect, devices};
+//! use bmap::connect;
 //!
-//! let dev = connect(None, "qc_ultra2").unwrap();
+//! // Auto-detect connected device
+//! let dev = connect(None, None).unwrap();
 //! println!("Battery: {}%", dev.battery().unwrap());
 //! println!("Mode: {}", dev.mode().unwrap());
 //! ```
@@ -27,19 +28,30 @@ pub use protocol::{Operator, BmapResponse};
 /// Connect to a BMAP device over Bluetooth RFCOMM.
 ///
 /// - `mac`: Bluetooth MAC address. Auto-detected if None.
-/// - `device_type`: Device type string (e.g. "qc_ultra2").
-pub fn connect(mac: Option<&str>, device_type: &str) -> BmapResult<BmapConnection<transport::RfcommTransport>> {
-    let mac = match mac {
-        Some(m) => m.to_string(),
-        None => discovery::find_bmap_device()
-            .ok_or_else(|| BmapError::NotFound(
-                "No BMAP device found. Pair via bluetoothctl or pass --mac".into()
-            ))?,
+/// - `device_type`: Device type string. Auto-detected if None.
+pub fn connect(mac: Option<&str>, device_type: Option<&str>) -> BmapResult<BmapConnection<transport::RfcommTransport>> {
+    let (mac, resolved_type) = match mac {
+        Some(m) => (m.to_string(), device_type.unwrap_or("qc_ultra2").to_string()),
+        None => {
+            let (detected_mac, detected_type) = discovery::find_bmap_device()
+                .ok_or_else(|| BmapError::NotFound(
+                    "No connected BMAP device found. Pair and connect via bluetoothctl or pass --mac".into()
+                ))?;
+            let dtype = device_type.map(|s| s.to_string()).unwrap_or(detected_type);
+            (detected_mac, dtype)
+        }
     };
 
-    let config = devices::get_device(device_type)
-        .ok_or_else(|| BmapError::InvalidArg(format!("Unknown device: {}", device_type)))?;
+    let config = devices::get_device(&resolved_type)
+        .ok_or_else(|| BmapError::InvalidArg(format!("Unknown device: {}", resolved_type)))?;
 
     let transport = transport::RfcommTransport::connect(&mac, config.rfcomm_channel)?;
+
+    // Some devices require an init packet before responding.
+    if let Some(init) = config.init_packet {
+        let pkt = protocol::bmap_packet(init.0, init.1, protocol::Operator::Get, &[]);
+        let _ = transport.send_recv(&pkt);
+    }
+
     Ok(BmapConnection::new(transport, config))
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -50,7 +50,7 @@ pub fn connect(mac: Option<&str>, device_type: Option<&str>) -> BmapResult<BmapC
     // Some devices require an init packet before responding.
     if let Some(init) = config.init_packet {
         let pkt = protocol::bmap_packet(init.0, init.1, protocol::Operator::Get, &[]);
-        let _ = transport.send_recv(&pkt);
+        transport.send_recv(&pkt)?;
     }
 
     Ok(BmapConnection::new(transport, config))

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -21,9 +21,9 @@ fn main() {
     }
 
     let mac = env::var("BMAP_MAC").ok();
-    let device_type = env::var("BMAP_DEVICE").unwrap_or_else(|_| "qc_ultra2".to_string());
+    let device_type = env::var("BMAP_DEVICE").ok();
 
-    let dev = match connect(mac.as_deref(), &device_type) {
+    let dev = match connect(mac.as_deref(), device_type.as_deref()) {
         Ok(d) => d,
         Err(e) => {
             eprintln!("Connection failed: {}", e);


### PR DESCRIPTION
## Summary

Ports the Python smart discovery (from main) to Rust and C++, so all three CLIs auto-detect connected devices without env vars.

**Discovery improvements (all languages):**
- Scans Modalias product ID to identify device model (QC Ultra 2 = 0x4082, QC35 = 0x4020)
- Prioritizes connected devices over paired-but-disconnected
- Uses device-specific RFCOMM channel (2 for Ultra 2, 8 for QC35)
- Sends init packet on connect for devices that need it (QC35 needs GET [0.1])

**Result:** `./bosectl status` / `cargo run -- status` / `cpp/build/bmapctl status` just work with whatever Bose headphone is connected. No BMAP_MAC or BMAP_DEVICE env vars needed.

## Test plan

- [x] `make test` — 181 tests pass
- [x] Python bosectl auto-detects QC35 and shows correct status
- [ ] Rust/C++ CLI auto-detect (need to rebuild and test against hardware)