### PR TITLE
Add BMAP device catalog and show model in status

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -18,6 +18,6 @@ target_link_libraries(bmapctl PRIVATE bmap bluetooth)
 
 # Tests
 enable_testing()
-add_executable(bmap_tests tests/test_main.cpp tests/test_protocol.cpp tests/test_parsers.cpp tests/test_connection.cpp)
+add_executable(bmap_tests tests/test_main.cpp tests/test_protocol.cpp tests/test_parsers.cpp tests/test_connection.cpp tests/test_catalog.cpp)
 target_link_libraries(bmap_tests PRIVATE bmap)
 add_test(NAME bmap_tests COMMAND bmap_tests)

--- a/cpp/src/bmap.h
+++ b/cpp/src/bmap.h
@@ -8,6 +8,7 @@
 #include "devices.h"
 #include "connection.h"
 #include "discovery.h"
+#include "catalog.h"
 
 namespace bmap {
 

--- a/cpp/src/catalog.h
+++ b/cpp/src/catalog.h
@@ -1,0 +1,92 @@
+// Bose device catalog — known BMAP-capable devices.
+// Source: https://downloads.bose.com/lookup.xml
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace bmap {
+
+/// All Bose USB devices share this vendor ID.
+constexpr uint16_t BOSE_USB_VID = 0x05A7;
+
+/// BMAP Bluetooth service UUID (SDP record).
+constexpr const char* BMAP_UUID = "00000000-deca-fade-deca-deafdecacaff";
+
+enum class Category { Headphones, Earbuds, Speaker };
+
+struct BoseDevice {
+    uint16_t product_id;
+    const char* codename;
+    const char* name;
+    Category category;
+    const char* config;  // nullptr if not yet supported
+};
+
+/// All known BMAP-capable Bose devices.
+inline const std::vector<BoseDevice>& catalog() {
+    static const std::vector<BoseDevice> devices = {
+        // Headphones
+        {0x4017, "kleos",     "QuietComfort 35",                 Category::Headphones, "qc35"},
+        {0x4020, "baywolf",   "QuietComfort 35 II",              Category::Headphones, "qc35"},
+        {0x4024, "goodyear",  "Noise Cancelling Headphones 700", Category::Headphones, nullptr},
+        {0x4061, "vedder",    "QuietComfort 45",                 Category::Headphones, nullptr},
+        {0x4082, "wolverine", "QuietComfort Ultra Headphones",   Category::Headphones, "qc_ultra2"},
+        // Earbuds
+        {0x4060, "olivia",    "QuietComfort Earbuds II",         Category::Earbuds, nullptr},
+        {0x4063, "edith",     "Ultra Open Earbuds",              Category::Earbuds, nullptr},
+        {0x4075, "prince",    "QuietComfort Ultra Earbuds",      Category::Earbuds, nullptr},
+        // Speakers
+        {0x402D, "revel",     "Home Speaker 300",                Category::Speaker, nullptr},
+        {0x402F, "lando",     "Portable Home Speaker",           Category::Speaker, nullptr},
+        {0x4039, "duran",     "SoundLink Flex",                  Category::Speaker, nullptr},
+        {0x403A, "gwen",      "SoundLink Revolve+ II",           Category::Speaker, nullptr},
+        {0x4066, "lonestarr", "SoundLink Max",                   Category::Speaker, nullptr},
+        {0x4073, "scotty",    "SoundLink Flex 2nd Gen",          Category::Speaker, nullptr},
+    };
+    return devices;
+}
+
+/// Look up a Bose device by product ID.
+inline const BoseDevice* lookup_device(uint16_t product_id) {
+    for (auto& d : catalog()) {
+        if (d.product_id == product_id) return &d;
+    }
+    return nullptr;
+}
+
+/// All devices with active library support.
+inline std::vector<const BoseDevice*> supported_devices() {
+    std::vector<const BoseDevice*> result;
+    for (auto& d : catalog()) {
+        if (d.config) result.push_back(&d);
+    }
+    return result;
+}
+
+/// Check if a product ID has an active library implementation.
+inline bool is_supported(uint16_t product_id) {
+    auto* d = lookup_device(product_id);
+    return d && d->config;
+}
+
+/// Get USB vendor/product ID pair for a known device.
+inline std::optional<std::pair<uint16_t, uint16_t>> usb_ids(uint16_t product_id) {
+    if (lookup_device(product_id))
+        return std::make_pair(BOSE_USB_VID, product_id);
+    return std::nullopt;
+}
+
+/// Generate a Bluetooth Modalias string for a known device.
+inline std::optional<std::string> modalias(uint16_t product_id) {
+    if (lookup_device(product_id)) {
+        char buf[40];
+        snprintf(buf, sizeof(buf), "bluetooth:v%04Xp%04Xd0000", BOSE_USB_VID, product_id);
+        return std::string(buf);
+    }
+    return std::nullopt;
+}
+
+} // namespace bmap

--- a/cpp/src/discovery.cpp
+++ b/cpp/src/discovery.cpp
@@ -1,5 +1,6 @@
 // Auto-detect paired BMAP devices via bluetoothctl (Linux).
 #include "discovery.h"
+#include "catalog.h"
 
 #include <array>
 #include <cstdio>
@@ -10,8 +11,6 @@
 #include <vector>
 
 namespace bmap {
-
-static const char* BMAP_UUID = "00000000-deca-fade-deca-deafdecacaff";
 
 static std::string exec(const std::string& cmd) {
     std::array<char, 256> buf;
@@ -24,22 +23,14 @@ static std::string exec(const std::string& cmd) {
     return result;
 }
 
-// Known BMAP devices (from https://downloads.bose.com/lookup.xml):
-//   0x4017 kleos    — QuietComfort 35           → qc35
-//   0x4020 baywolf  — QuietComfort 35 II        → qc35
-//   0x4024 goodyear — NC Headphones 700         (unsupported)
-//   0x4060 olivia   — QC Earbuds II             (unsupported)
-//   0x4061 vedder   — QuietComfort 45           (unsupported)
-//   0x4063 edith    — Ultra Open Earbuds        (unsupported)
-//   0x4075 prince   — QC Ultra Earbuds          (unsupported)
-//   0x4082 wolverine — QC Ultra Headphones      → qc_ultra2
+// Detect device type from Modalias product ID via catalog lookup.
 static std::string detect_device_type(const std::string& info) {
     std::regex modalias_re(R"(Modalias:\s*bluetooth:v[0-9A-Fa-f]{4}p([0-9A-Fa-f]{4}))");
     std::smatch match;
     if (std::regex_search(info, match, modalias_re)) {
         unsigned int product_id = std::stoul(match[1].str(), nullptr, 16);
-        if (product_id == 0x4082) return "qc_ultra2";                  // wolverine
-        if (product_id == 0x4020 || product_id == 0x4017) return "qc35"; // baywolf / kleos
+        auto* dev = lookup_device(static_cast<uint16_t>(product_id));
+        if (dev && dev->config) return dev->config;
     }
     return "qc_ultra2";
 }

--- a/cpp/src/discovery.cpp
+++ b/cpp/src/discovery.cpp
@@ -24,13 +24,22 @@ static std::string exec(const std::string& cmd) {
     return result;
 }
 
+// Known BMAP devices (from https://downloads.bose.com/lookup.xml):
+//   0x4017 kleos    — QuietComfort 35           → qc35
+//   0x4020 baywolf  — QuietComfort 35 II        → qc35
+//   0x4024 goodyear — NC Headphones 700         (unsupported)
+//   0x4060 olivia   — QC Earbuds II             (unsupported)
+//   0x4061 vedder   — QuietComfort 45           (unsupported)
+//   0x4063 edith    — Ultra Open Earbuds        (unsupported)
+//   0x4075 prince   — QC Ultra Earbuds          (unsupported)
+//   0x4082 wolverine — QC Ultra Headphones      → qc_ultra2
 static std::string detect_device_type(const std::string& info) {
     std::regex modalias_re(R"(Modalias:\s*bluetooth:v[0-9A-Fa-f]{4}p([0-9A-Fa-f]{4}))");
     std::smatch match;
     if (std::regex_search(info, match, modalias_re)) {
         unsigned int product_id = std::stoul(match[1].str(), nullptr, 16);
-        if (product_id == 0x4082) return "qc_ultra2";
-        if (product_id == 0x4020 || product_id == 0x400C) return "qc35";
+        if (product_id == 0x4082) return "qc_ultra2";                  // wolverine
+        if (product_id == 0x4020 || product_id == 0x4017) return "qc35"; // baywolf / kleos
     }
     return "qc_ultra2";
 }

--- a/cpp/src/main.cpp
+++ b/cpp/src/main.cpp
@@ -59,6 +59,7 @@ int main(int argc, char** argv) {
     try {
         if (cmd == "status") {
             auto s = dev.status();
+            std::cout << "  Model        " << dev.config().info.name << "\n";
             std::cout << "  Battery      " << (int)s.battery << "%\n";
             if (!s.mode.empty())
                 std::cout << "  Mode         " << s.mode << "\n";

--- a/cpp/tests/test_catalog.cpp
+++ b/cpp/tests/test_catalog.cpp
@@ -1,0 +1,60 @@
+// Tests for Bose device catalog.
+#include "test_common.h"
+#include "../src/catalog.h"
+
+using namespace bmap;
+
+TEST(catalog_lookup_known) {
+    auto* dev = lookup_device(0x4082);
+    ASSERT_TRUE(dev != nullptr);
+    ASSERT_EQ(std::string(dev->codename), std::string("wolverine"));
+    ASSERT_TRUE(dev->config != nullptr);
+    ASSERT_EQ(std::string(dev->config), std::string("qc_ultra2"));
+}
+
+TEST(catalog_lookup_qc35) {
+    auto* dev = lookup_device(0x4020);
+    ASSERT_TRUE(dev != nullptr);
+    ASSERT_EQ(std::string(dev->codename), std::string("baywolf"));
+    ASSERT_EQ(std::string(dev->config), std::string("qc35"));
+}
+
+TEST(catalog_lookup_qc35_original) {
+    auto* dev = lookup_device(0x4017);
+    ASSERT_TRUE(dev != nullptr);
+    ASSERT_EQ(std::string(dev->codename), std::string("kleos"));
+}
+
+TEST(catalog_lookup_unknown) {
+    ASSERT_TRUE(lookup_device(0xFFFF) == nullptr);
+}
+
+TEST(catalog_is_supported) {
+    ASSERT_TRUE(is_supported(0x4082));
+    ASSERT_TRUE(is_supported(0x4020));
+    ASSERT_FALSE(is_supported(0x4024));  // NCH 700, no config
+    ASSERT_FALSE(is_supported(0xFFFF));
+}
+
+TEST(catalog_supported_devices) {
+    auto devs = supported_devices();
+    ASSERT_TRUE(devs.size() >= 3u);
+    for (auto* d : devs) {
+        ASSERT_TRUE(d->config != nullptr);
+    }
+}
+
+TEST(catalog_usb_ids) {
+    auto ids = usb_ids(0x4082);
+    ASSERT_TRUE(ids.has_value());
+    ASSERT_EQ(ids->first, BOSE_USB_VID);
+    ASSERT_EQ(ids->second, static_cast<uint16_t>(0x4082));
+    ASSERT_FALSE(usb_ids(0xFFFF).has_value());
+}
+
+TEST(catalog_modalias) {
+    auto m = modalias(0x4082);
+    ASSERT_TRUE(m.has_value());
+    ASSERT_EQ(*m, std::string("bluetooth:v05A7p4082d0000"));
+    ASSERT_FALSE(modalias(0xFFFF).has_value());
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -293,16 +293,89 @@ The library uses SETGET (not SET) for all writes and START for mode
 switching. This gives full control over settings, profiles, and modes
 without any authentication.
 
+## Device Catalog
+
+The catalog module (`catalog.py` / `catalog.rs` / `catalog.h`) is the
+single source of truth for all known Bose BMAP devices. It's sourced from
+Bose's firmware manifest at `downloads.bose.com/lookup.xml`.
+
+```mermaid
+graph TD
+    CAT[Device Catalog<br/>14 known BMAP devices] --> SUP[Supported<br/>config ≠ None]
+    CAT --> UNSUP[Recognized but Unsupported<br/>config = None]
+    SUP --> DISC[Discovery<br/>PID → config lookup]
+    SUP --> CFG[Device Configs<br/>qc_ultra2, qc35]
+    DISC --> CONN[connect&#40;&#41;]
+    CFG --> CONN
+
+    style CAT fill:#ff9f43,stroke:#333,color:#fff
+    style SUP fill:#26de81,stroke:#333,color:#fff
+    style UNSUP fill:#778ca3,stroke:#333,color:#fff
+    style DISC fill:#4a9eff,stroke:#333,color:#fff
+    style CFG fill:#4a9eff,stroke:#333,color:#fff
+    style CONN fill:#4a9eff,stroke:#333,color:#fff
+```
+
+Each catalog entry carries:
+
+| Field | Description | Example |
+|-------|-------------|---------|
+| `product_id` | USB PID / Bluetooth Modalias ID | `0x4082` |
+| `codename` | Bose internal codename | `"wolverine"` |
+| `name` | Marketing product name | `"QuietComfort Ultra Headphones"` |
+| `category` | `headphones`, `earbuds`, or `speaker` | `headphones` |
+| `config` | Library config key, or None | `"qc_ultra2"` |
+
+**Public API** (identical across all three libraries):
+
+```
+lookup_device(0x4082)    → BoseDevice{wolverine, "QC Ultra Headphones", config="qc_ultra2"}
+is_supported(0x4024)     → False (NCH 700: recognized, no config yet)
+supported_devices()      → [kleos, baywolf, wolverine]
+known_devices()          → all 14 entries
+usb_ids(0x4082)          → (0x05A7, 0x4082)
+modalias(0x4082)         → "bluetooth:v05A7p4082d0000"
+```
+
+The USB vendor ID `0x05A7` is shared by all Bose devices. The product ID
+appears in both USB descriptors (DFU mode) and Bluetooth Modalias strings
+(normal mode), making it the universal device identifier.
+
+Discovery uses the catalog to resolve product IDs to config keys. Devices
+with `config=None` are recognized (logged, not errored) but fall back to
+a default config since they don't have a tested implementation yet.
+
+### Supported Devices
+
+| PID | Codename | Product | Config |
+|-----|----------|---------|--------|
+| `0x4017` | kleos | QuietComfort 35 | `qc35` |
+| `0x4020` | baywolf | QuietComfort 35 II | `qc35` |
+| `0x4082` | wolverine | QuietComfort Ultra Headphones | `qc_ultra2` |
+
+### Known Unsupported (Future Targets)
+
+| PID | Codename | Product | Category |
+|-----|----------|---------|----------|
+| `0x4024` | goodyear | Noise Cancelling Headphones 700 | headphones |
+| `0x4061` | vedder | QuietComfort 45 | headphones |
+| `0x4060` | olivia | QuietComfort Earbuds II | earbuds |
+| `0x4063` | edith | Ultra Open Earbuds | earbuds |
+| `0x4075` | prince | QuietComfort Ultra Earbuds | earbuds |
+| `0x4039` | duran | SoundLink Flex | speaker |
+| `0x4073` | scotty | SoundLink Flex 2nd Gen | speaker |
+
 ## Adding a New Device
 
-To add support for a new Bose headphone model:
+To add support for a new Bose device:
 
-1. **Discover the RFCOMM channel** — try channels 2 and 8
-2. **Check if an init packet is needed** — send GET [0.1] and see if subsequent commands work
-3. **Probe features** — GET on known function addresses to see what responds
-4. **Create a device config** with the discovered addresses and parsers
-5. **Register in discovery** — add the Modalias product ID mapping
+1. **Add to the catalog** — add its PID, codename, and name with `config=None`
+2. **Discover the RFCOMM channel** — try channels 2 and 8
+3. **Check if an init packet is needed** — send GET [0.1] and see if subsequent commands work
+4. **Probe features** — GET on known function addresses to see what responds
+5. **Create a device config** with the discovered addresses and parsers
 6. **Register in the device registry** — add to `get_device()` / `DEVICES`
+7. **Set config in catalog** — change `None` to the new config key
 
 No changes to `BmapConnection` or the transport layer should be needed.
 Device-specific parsing (e.g. different ModeConfig layouts) is handled by
@@ -320,6 +393,7 @@ are in how each language expresses the patterns.
 ```
 pybmap/
 ├── __init__.py          # connect() entry point, public API re-exports
+├── catalog.py           # Device catalog (PIDs, codenames, USB/Modalias IDs)
 ├── protocol.py          # Packet codec (bmap_packet, parse_response)
 ├── transport.py         # RfcommTransport (AF_BLUETOOTH socket)
 ├── connection.py        # BmapConnection class
@@ -360,6 +434,7 @@ parser tests (parsers are pure functions). Connection tests use a
 ```
 rust/src/
 ├── lib.rs               # connect() entry point, public re-exports
+├── catalog.rs           # Device catalog (PIDs, codenames, USB/Modalias IDs)
 ├── protocol.rs          # Packet codec, BmapResponse struct
 ├── transport.rs         # Transport trait + RfcommTransport (libc sockets)
 ├── connection.rs        # BmapConnection<T: Transport> generic struct
@@ -414,6 +489,7 @@ pub enum BmapError {
 ```
 cpp/src/
 ├── bmap.h               # connect() function, public header
+├── catalog.h            # Device catalog (PIDs, codenames, USB/Modalias IDs)
 ├── protocol.h           # Packet codec (header-only)
 ├── transport.h          # Transport abstract class
 ├── transport.cpp        # RfcommTransport (BlueZ sockets)

--- a/python/pybmap/__init__.py
+++ b/python/pybmap/__init__.py
@@ -18,6 +18,11 @@ from .connection import BmapConnection
 from .transport import RfcommTransport
 from .discovery import find_bmap_device
 from .devices import DEVICES, get_device
+from .catalog import (
+    BOSE_USB_VID, BMAP_UUID, BoseDevice, CATALOG,
+    lookup_device, known_devices, supported_devices, is_supported,
+    usb_ids, modalias,
+)
 from .errors import (
     BmapError, BmapConnectionError, BmapAuthError,
     BmapDeviceError, BmapTimeoutError, BmapNotFoundError,

--- a/python/pybmap/catalog.py
+++ b/python/pybmap/catalog.py
@@ -1,0 +1,123 @@
+"""Bose device catalog — known BMAP-capable devices.
+
+Source: https://downloads.bose.com/lookup.xml
+USB VID 0x05a7 is shared by all Bose devices.
+
+This module is the authoritative device registry. Discovery and
+connection code reference it for product ID → device type mapping.
+"""
+
+from collections import namedtuple
+
+# All Bose USB devices share this vendor ID.
+BOSE_USB_VID = 0x05A7
+
+# BMAP Bluetooth service UUID (SDP record).
+BMAP_UUID = "00000000-deca-fade-deca-deafdecacaff"
+
+BoseDevice = namedtuple("BoseDevice", [
+    "product_id",   # USB PID / Bluetooth Modalias product ID
+    "codename",     # Internal Bose codename (from firmware URLs)
+    "name",         # Marketing product name
+    "category",     # "headphones", "earbuds", or "speaker"
+    "config",       # Library config key ("qc_ultra2", "qc35") or None
+])
+
+
+# ── Device Catalog ──────────────────────────────────────────────────────────
+# All known BMAP-capable Bose devices. Entries with config=None are
+# recognized but not yet supported — they serve as a roadmap for
+# future protocol implementations.
+
+CATALOG = {
+    # Headphones
+    0x4017: BoseDevice(0x4017, "kleos",     "QuietComfort 35",                "headphones", "qc35"),
+    0x4020: BoseDevice(0x4020, "baywolf",   "QuietComfort 35 II",             "headphones", "qc35"),
+    0x4024: BoseDevice(0x4024, "goodyear",  "Noise Cancelling Headphones 700","headphones", None),
+    0x4061: BoseDevice(0x4061, "vedder",    "QuietComfort 45",                "headphones", None),
+    0x4082: BoseDevice(0x4082, "wolverine", "QuietComfort Ultra Headphones",  "headphones", "qc_ultra2"),
+
+    # Earbuds
+    0x4060: BoseDevice(0x4060, "olivia",    "QuietComfort Earbuds II",        "earbuds", None),
+    0x4063: BoseDevice(0x4063, "edith",     "Ultra Open Earbuds",             "earbuds", None),
+    0x4075: BoseDevice(0x4075, "prince",    "QuietComfort Ultra Earbuds",     "earbuds", None),
+
+    # Speakers
+    0x402D: BoseDevice(0x402D, "revel",     "Home Speaker 300",               "speaker", None),
+    0x402F: BoseDevice(0x402F, "lando",     "Portable Home Speaker",          "speaker", None),
+    0x4039: BoseDevice(0x4039, "duran",     "SoundLink Flex",                 "speaker", None),
+    0x403A: BoseDevice(0x403A, "gwen",      "SoundLink Revolve+ II",          "speaker", None),
+    0x4066: BoseDevice(0x4066, "lonestarr", "SoundLink Max",                  "speaker", None),
+    0x4073: BoseDevice(0x4073, "scotty",    "SoundLink Flex 2nd Gen",         "speaker", None),
+}
+
+
+def lookup_device(product_id):
+    """Look up a Bose device by product ID.
+
+    Args:
+        product_id: USB PID or Bluetooth Modalias product ID (int).
+
+    Returns:
+        BoseDevice namedtuple, or None if unknown.
+    """
+    return CATALOG.get(product_id)
+
+
+def known_devices():
+    """All known BMAP-capable Bose devices.
+
+    Returns:
+        List of BoseDevice namedtuples.
+    """
+    return list(CATALOG.values())
+
+
+def supported_devices():
+    """Devices with active library support (config is not None).
+
+    Returns:
+        List of BoseDevice namedtuples.
+    """
+    return [d for d in CATALOG.values() if d.config is not None]
+
+
+def is_supported(product_id):
+    """Check if a product ID has an active library implementation.
+
+    Args:
+        product_id: USB PID or Bluetooth Modalias product ID (int).
+
+    Returns:
+        True if the device has a config implementation.
+    """
+    entry = CATALOG.get(product_id)
+    return entry is not None and entry.config is not None
+
+
+def usb_ids(product_id):
+    """Get USB vendor/product ID pair for a known device.
+
+    Args:
+        product_id: Bose product ID (int).
+
+    Returns:
+        (vendor_id, product_id) tuple, or None if unknown.
+    """
+    if product_id in CATALOG:
+        return (BOSE_USB_VID, product_id)
+    return None
+
+
+def modalias(product_id):
+    """Generate a Bluetooth Modalias string for a known device.
+
+    Args:
+        product_id: Bose product ID (int).
+
+    Returns:
+        Modalias string like "bluetooth:v009Bp4082d0000", or None.
+    """
+    if product_id in CATALOG:
+        return "bluetooth:v%04Xp%04Xd0000" % (BOSE_USB_VID, product_id)
+    return None

--- a/python/pybmap/cli.py
+++ b/python/pybmap/cli.py
@@ -47,6 +47,7 @@ def row(label, value, color=None):
 
 def cmd_status(dev):
     s = dev.status()
+    row("Model", dev.device_info.get("name", "Unknown"), C_MAGENTA)
     batt_color = C_GREEN if s.battery > 30 else C_YELLOW if s.battery > 10 else C_RED
     row("Battery", "%d%%" % s.battery, batt_color)
     if s.mode:

--- a/python/pybmap/discovery.py
+++ b/python/pybmap/discovery.py
@@ -6,12 +6,35 @@ import subprocess
 # Bose BMAP service UUID found in SDP records.
 BMAP_UUID = "00000000-deca-fade-deca-deafdecacaff"
 
-# Known product IDs from Modalias (bluetooth:vXXXXpYYYYdZZZZ).
-# The product ID (pYYYY) identifies the device model.
+# BMAP-capable Bose devices from https://downloads.bose.com/lookup.xml
+# Keyed by USB PID (also appears in Bluetooth Modalias).
+# Devices with a config value are actively supported; None = recognized but unsupported.
+BOSE_DEVICES = {
+    # Headphones
+    0x4017: ("kleos",        "QuietComfort 35",              "qc35"),
+    0x4020: ("baywolf",      "QuietComfort 35 II",           "qc35"),
+    0x4024: ("goodyear",     "Noise Cancelling Headphones 700", None),
+    0x4061: ("vedder",       "QuietComfort 45",              None),
+    0x4082: ("wolverine",    "QuietComfort Ultra Headphones", "qc_ultra2"),
+    # Earbuds
+    0x4060: ("olivia",       "QuietComfort Earbuds II",      None),
+    0x4063: ("edith",        "Ultra Open Earbuds",           None),
+    0x4075: ("prince",       "QuietComfort Ultra Earbuds",   None),
+    # Speakers
+    0x4024: ("goodyear",     "Noise Cancelling Headphones 700", None),
+    0x402D: ("revel",        "Home Speaker 300",             None),
+    0x402F: ("lando",        "Portable Home Speaker",        None),
+    0x4039: ("duran",        "SoundLink Flex",               None),
+    0x403A: ("gwen",         "SoundLink Revolve+ II",        None),
+    0x4066: ("lonestarr",    "SoundLink Max",                None),
+    0x4073: ("scotty",       "SoundLink Flex 2nd Gen",       None),
+}
+
+# Active device configs — subset of BOSE_DEVICES that have implementations.
 PRODUCT_ID_MAP = {
-    0x4082: "qc_ultra2",
-    0x4020: "qc35",
-    0x400C: "qc35",       # QC35 II variant
+    pid: config
+    for pid, (_, _, config) in BOSE_DEVICES.items()
+    if config is not None
 }
 
 

--- a/python/pybmap/discovery.py
+++ b/python/pybmap/discovery.py
@@ -3,39 +3,7 @@
 import re
 import subprocess
 
-# Bose BMAP service UUID found in SDP records.
-BMAP_UUID = "00000000-deca-fade-deca-deafdecacaff"
-
-# BMAP-capable Bose devices from https://downloads.bose.com/lookup.xml
-# Keyed by USB PID (also appears in Bluetooth Modalias).
-# Devices with a config value are actively supported; None = recognized but unsupported.
-BOSE_DEVICES = {
-    # Headphones
-    0x4017: ("kleos",        "QuietComfort 35",              "qc35"),
-    0x4020: ("baywolf",      "QuietComfort 35 II",           "qc35"),
-    0x4024: ("goodyear",     "Noise Cancelling Headphones 700", None),
-    0x4061: ("vedder",       "QuietComfort 45",              None),
-    0x4082: ("wolverine",    "QuietComfort Ultra Headphones", "qc_ultra2"),
-    # Earbuds
-    0x4060: ("olivia",       "QuietComfort Earbuds II",      None),
-    0x4063: ("edith",        "Ultra Open Earbuds",           None),
-    0x4075: ("prince",       "QuietComfort Ultra Earbuds",   None),
-    # Speakers
-    0x4024: ("goodyear",     "Noise Cancelling Headphones 700", None),
-    0x402D: ("revel",        "Home Speaker 300",             None),
-    0x402F: ("lando",        "Portable Home Speaker",        None),
-    0x4039: ("duran",        "SoundLink Flex",               None),
-    0x403A: ("gwen",         "SoundLink Revolve+ II",        None),
-    0x4066: ("lonestarr",    "SoundLink Max",                None),
-    0x4073: ("scotty",       "SoundLink Flex 2nd Gen",       None),
-}
-
-# Active device configs — subset of BOSE_DEVICES that have implementations.
-PRODUCT_ID_MAP = {
-    pid: config
-    for pid, (_, _, config) in BOSE_DEVICES.items()
-    if config is not None
-}
+from .catalog import BMAP_UUID, CATALOG
 
 
 def find_bmap_device():
@@ -108,6 +76,7 @@ def _detect_device_type(info_text):
     match = re.search(r"Modalias:\s*bluetooth:v[0-9A-Fa-f]{4}p([0-9A-Fa-f]{4})", info_text)
     if match:
         product_id = int(match.group(1), 16)
-        if product_id in PRODUCT_ID_MAP:
-            return PRODUCT_ID_MAP[product_id]
+        entry = CATALOG.get(product_id)
+        if entry and entry.config:
+            return entry.config
     return "qc_ultra2"  # default for unknown BMAP devices

--- a/python/pybmap/discovery.py
+++ b/python/pybmap/discovery.py
@@ -3,7 +3,7 @@
 import re
 import subprocess
 
-from .catalog import BMAP_UUID, CATALOG
+from .catalog import BMAP_UUID, lookup_device
 
 
 def find_bmap_device():
@@ -66,17 +66,17 @@ def _scan_paired_devices():
 
 
 def _detect_device_type(info_text):
-    """Extract device type from bluetoothctl info output.
+    """Extract device type from bluetoothctl info output via catalog lookup.
 
     Parses Modalias (bluetooth:vXXXXpYYYYdZZZZ) to get the product ID,
-    then looks it up in PRODUCT_ID_MAP.
+    then looks it up in the device catalog.
 
     Falls back to "qc_ultra2" if the product ID is unknown.
     """
     match = re.search(r"Modalias:\s*bluetooth:v[0-9A-Fa-f]{4}p([0-9A-Fa-f]{4})", info_text)
     if match:
         product_id = int(match.group(1), 16)
-        entry = CATALOG.get(product_id)
+        entry = lookup_device(product_id)
         if entry and entry.config:
             return entry.config
     return "qc_ultra2"  # default for unknown BMAP devices

--- a/python/tests/test_catalog.py
+++ b/python/tests/test_catalog.py
@@ -1,0 +1,95 @@
+"""Tests for the Bose device catalog."""
+
+from pybmap.catalog import (
+    BOSE_USB_VID, CATALOG, BoseDevice,
+    lookup_device, known_devices, supported_devices,
+    is_supported, usb_ids, modalias,
+)
+
+
+class TestLookup:
+    def test_known_device(self):
+        dev = lookup_device(0x4082)
+        assert dev is not None
+        assert dev.codename == "wolverine"
+        assert dev.name == "QuietComfort Ultra Headphones"
+        assert dev.config == "qc_ultra2"
+
+    def test_qc35(self):
+        dev = lookup_device(0x4020)
+        assert dev.codename == "baywolf"
+        assert dev.config == "qc35"
+
+    def test_qc35_original(self):
+        dev = lookup_device(0x4017)
+        assert dev.codename == "kleos"
+        assert dev.config == "qc35"
+
+    def test_unsupported_known(self):
+        dev = lookup_device(0x4024)
+        assert dev is not None
+        assert dev.codename == "goodyear"
+        assert dev.config is None
+
+    def test_unknown(self):
+        assert lookup_device(0xFFFF) is None
+
+
+class TestSupport:
+    def test_is_supported(self):
+        assert is_supported(0x4082)
+        assert is_supported(0x4020)
+        assert is_supported(0x4017)
+
+    def test_not_supported(self):
+        assert not is_supported(0x4024)  # NCH 700
+        assert not is_supported(0xFFFF)  # unknown
+
+    def test_supported_devices(self):
+        devs = supported_devices()
+        assert len(devs) >= 3  # kleos, baywolf, wolverine
+        assert all(d.config is not None for d in devs)
+
+    def test_known_devices(self):
+        devs = known_devices()
+        assert len(devs) == len(CATALOG)
+
+
+class TestUsbIds:
+    def test_known(self):
+        vid, pid = usb_ids(0x4082)
+        assert vid == BOSE_USB_VID
+        assert pid == 0x4082
+
+    def test_unknown(self):
+        assert usb_ids(0xFFFF) is None
+
+
+class TestModalias:
+    def test_known(self):
+        m = modalias(0x4082)
+        assert m == "bluetooth:v05A7p4082d0000"
+
+    def test_qc35(self):
+        m = modalias(0x4020)
+        assert m == "bluetooth:v05A7p4020d0000"
+
+    def test_unknown(self):
+        assert modalias(0xFFFF) is None
+
+
+class TestCatalogIntegrity:
+    def test_no_duplicate_pids(self):
+        pids = [d.product_id for d in CATALOG.values()]
+        assert len(pids) == len(set(pids))
+
+    def test_all_have_codename(self):
+        for dev in CATALOG.values():
+            assert dev.codename, "Device 0x%04x missing codename" % dev.product_id
+
+    def test_all_have_name(self):
+        for dev in CATALOG.values():
+            assert dev.name, "Device 0x%04x missing name" % dev.product_id
+
+    def test_vid_constant(self):
+        assert BOSE_USB_VID == 0x05A7

--- a/rust/src/catalog.rs
+++ b/rust/src/catalog.rs
@@ -1,0 +1,129 @@
+//! Bose device catalog — known BMAP-capable devices.
+//!
+//! Source: <https://downloads.bose.com/lookup.xml>
+
+/// All Bose USB devices share this vendor ID.
+pub const BOSE_USB_VID: u16 = 0x05A7;
+
+/// BMAP Bluetooth service UUID (SDP record).
+pub const BMAP_UUID: &str = "00000000-deca-fade-deca-deafdecacaff";
+
+/// Device category.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Category {
+    Headphones,
+    Earbuds,
+    Speaker,
+}
+
+/// A known Bose BMAP device.
+#[derive(Debug, Clone)]
+pub struct BoseDevice {
+    pub product_id: u16,
+    pub codename: &'static str,
+    pub name: &'static str,
+    pub category: Category,
+    /// Library config key, or None if not yet supported.
+    pub config: Option<&'static str>,
+}
+
+/// All known BMAP-capable Bose devices.
+pub const CATALOG: &[BoseDevice] = &[
+    // Headphones
+    BoseDevice { product_id: 0x4017, codename: "kleos",     name: "QuietComfort 35",                 category: Category::Headphones, config: Some("qc35") },
+    BoseDevice { product_id: 0x4020, codename: "baywolf",   name: "QuietComfort 35 II",              category: Category::Headphones, config: Some("qc35") },
+    BoseDevice { product_id: 0x4024, codename: "goodyear",  name: "Noise Cancelling Headphones 700", category: Category::Headphones, config: None },
+    BoseDevice { product_id: 0x4061, codename: "vedder",    name: "QuietComfort 45",                 category: Category::Headphones, config: None },
+    BoseDevice { product_id: 0x4082, codename: "wolverine", name: "QuietComfort Ultra Headphones",   category: Category::Headphones, config: Some("qc_ultra2") },
+    // Earbuds
+    BoseDevice { product_id: 0x4060, codename: "olivia",    name: "QuietComfort Earbuds II",         category: Category::Earbuds, config: None },
+    BoseDevice { product_id: 0x4063, codename: "edith",     name: "Ultra Open Earbuds",              category: Category::Earbuds, config: None },
+    BoseDevice { product_id: 0x4075, codename: "prince",    name: "QuietComfort Ultra Earbuds",      category: Category::Earbuds, config: None },
+    // Speakers
+    BoseDevice { product_id: 0x402D, codename: "revel",     name: "Home Speaker 300",                category: Category::Speaker, config: None },
+    BoseDevice { product_id: 0x402F, codename: "lando",     name: "Portable Home Speaker",           category: Category::Speaker, config: None },
+    BoseDevice { product_id: 0x4039, codename: "duran",     name: "SoundLink Flex",                  category: Category::Speaker, config: None },
+    BoseDevice { product_id: 0x403A, codename: "gwen",      name: "SoundLink Revolve+ II",           category: Category::Speaker, config: None },
+    BoseDevice { product_id: 0x4066, codename: "lonestarr", name: "SoundLink Max",                   category: Category::Speaker, config: None },
+    BoseDevice { product_id: 0x4073, codename: "scotty",    name: "SoundLink Flex 2nd Gen",          category: Category::Speaker, config: None },
+];
+
+/// Look up a Bose device by product ID.
+pub fn lookup_device(product_id: u16) -> Option<&'static BoseDevice> {
+    CATALOG.iter().find(|d| d.product_id == product_id)
+}
+
+/// All devices with active library support.
+pub fn supported_devices() -> Vec<&'static BoseDevice> {
+    CATALOG.iter().filter(|d| d.config.is_some()).collect()
+}
+
+/// Check if a product ID has an active library implementation.
+pub fn is_supported(product_id: u16) -> bool {
+    lookup_device(product_id).map_or(false, |d| d.config.is_some())
+}
+
+/// Get USB vendor/product ID pair for a known device.
+pub fn usb_ids(product_id: u16) -> Option<(u16, u16)> {
+    if lookup_device(product_id).is_some() {
+        Some((BOSE_USB_VID, product_id))
+    } else {
+        None
+    }
+}
+
+/// Generate a Bluetooth Modalias string for a known device.
+pub fn modalias(product_id: u16) -> Option<String> {
+    if lookup_device(product_id).is_some() {
+        Some(format!("bluetooth:v{:04X}p{:04X}d0000", BOSE_USB_VID, product_id))
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_lookup_known() {
+        let dev = lookup_device(0x4082).unwrap();
+        assert_eq!(dev.codename, "wolverine");
+        assert_eq!(dev.config, Some("qc_ultra2"));
+    }
+
+    #[test]
+    fn test_lookup_unknown() {
+        assert!(lookup_device(0xFFFF).is_none());
+    }
+
+    #[test]
+    fn test_is_supported() {
+        assert!(is_supported(0x4082));
+        assert!(is_supported(0x4020));
+        assert!(!is_supported(0x4024)); // NCH 700, no config
+        assert!(!is_supported(0xFFFF));
+    }
+
+    #[test]
+    fn test_supported_devices() {
+        let devs = supported_devices();
+        assert!(devs.len() >= 2); // at least QC35 + QC Ultra 2
+        assert!(devs.iter().all(|d| d.config.is_some()));
+    }
+
+    #[test]
+    fn test_usb_ids() {
+        let (vid, pid) = usb_ids(0x4082).unwrap();
+        assert_eq!(vid, 0x05A7);
+        assert_eq!(pid, 0x4082);
+        assert!(usb_ids(0xFFFF).is_none());
+    }
+
+    #[test]
+    fn test_modalias() {
+        let m = modalias(0x4082).unwrap();
+        assert_eq!(m, "bluetooth:v05A7p4082d0000");
+        assert!(modalias(0xFFFF).is_none());
+    }
+}

--- a/rust/src/discovery.rs
+++ b/rust/src/discovery.rs
@@ -2,8 +2,7 @@
 
 use std::process::Command;
 
-/// BMAP service UUID found in SDP records.
-pub const BMAP_UUID: &str = "00000000-deca-fade-deca-deafdecacaff";
+use crate::catalog::{self, BMAP_UUID};
 
 /// A discovered BMAP device.
 #[derive(Debug, Clone)]
@@ -73,35 +72,25 @@ pub fn scan_paired_devices() -> Vec<DiscoveredDevice> {
     candidates
 }
 
-/// Detect device type from Modalias product ID.
-///
-/// Known BMAP devices (from https://downloads.bose.com/lookup.xml):
-///   0x4017 kleos    — QuietComfort 35           → qc35
-///   0x4020 baywolf  — QuietComfort 35 II        → qc35
-///   0x4024 goodyear — NC Headphones 700         (unsupported)
-///   0x4060 olivia   — QC Earbuds II             (unsupported)
-///   0x4061 vedder   — QuietComfort 45           (unsupported)
-///   0x4063 edith    — Ultra Open Earbuds        (unsupported)
-///   0x4075 prince   — QC Ultra Earbuds          (unsupported)
-///   0x4082 wolverine — QC Ultra Headphones      → qc_ultra2
+/// Detect device type from Modalias product ID via catalog lookup.
 fn detect_device_type(info: &str) -> String {
     // Modalias format: bluetooth:vXXXXpYYYYdZZZZ
     for line in info.lines() {
         let trimmed = line.trim();
         if let Some(rest) = trimmed.strip_prefix("Modalias:") {
             let rest = rest.trim();
-            // Match "bluetooth:vXXXXpYYYYdZZZZ" and extract YYYY
             if let Some(bt_rest) = rest.strip_prefix("bluetooth:v") {
-                if bt_rest.len() >= 9 {  // "XXXXpYYYY" minimum
-                    let after_vendor = &bt_rest[4..];  // skip vendor "XXXX"
+                if bt_rest.len() >= 9 {
+                    let after_vendor = &bt_rest[4..];
                     if after_vendor.starts_with('p') {
                         let id_str = &after_vendor[1..5];
                         if let Ok(product_id) = u16::from_str_radix(id_str, 16) {
-                            return match product_id {
-                                0x4082 => "qc_ultra2".to_string(),          // wolverine
-                                0x4020 | 0x4017 => "qc35".to_string(),     // baywolf / kleos
-                                _ => "qc_ultra2".to_string(),
-                            };
+                            if let Some(dev) = catalog::lookup_device(product_id) {
+                                if let Some(config) = dev.config {
+                                    return config.to_string();
+                                }
+                            }
+                            return "qc_ultra2".to_string();
                         }
                     }
                 }

--- a/rust/src/discovery.rs
+++ b/rust/src/discovery.rs
@@ -74,6 +74,16 @@ pub fn scan_paired_devices() -> Vec<DiscoveredDevice> {
 }
 
 /// Detect device type from Modalias product ID.
+///
+/// Known BMAP devices (from https://downloads.bose.com/lookup.xml):
+///   0x4017 kleos    — QuietComfort 35           → qc35
+///   0x4020 baywolf  — QuietComfort 35 II        → qc35
+///   0x4024 goodyear — NC Headphones 700         (unsupported)
+///   0x4060 olivia   — QC Earbuds II             (unsupported)
+///   0x4061 vedder   — QuietComfort 45           (unsupported)
+///   0x4063 edith    — Ultra Open Earbuds        (unsupported)
+///   0x4075 prince   — QC Ultra Earbuds          (unsupported)
+///   0x4082 wolverine — QC Ultra Headphones      → qc_ultra2
 fn detect_device_type(info: &str) -> String {
     // Modalias format: bluetooth:vXXXXpYYYYdZZZZ
     for line in info.lines() {
@@ -88,8 +98,8 @@ fn detect_device_type(info: &str) -> String {
                         let id_str = &after_vendor[1..5];
                         if let Ok(product_id) = u16::from_str_radix(id_str, 16) {
                             return match product_id {
-                                0x4082 => "qc_ultra2".to_string(),
-                                0x4020 | 0x400C => "qc35".to_string(),
+                                0x4082 => "qc_ultra2".to_string(),          // wolverine
+                                0x4020 | 0x4017 => "qc35".to_string(),     // baywolf / kleos
                                 _ => "qc_ultra2".to_string(),
                             };
                         }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -18,6 +18,7 @@ pub mod device;
 pub mod devices;
 pub mod connection;
 pub mod discovery;
+pub mod catalog;
 
 pub use connection::BmapConnection;
 pub use transport::Transport;

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -224,6 +224,7 @@ fn cmd_status(dev: &bmap::BmapConnection<impl bmap::Transport>) -> Result<(), Bm
     let cnc_bar: String = "█".repeat(s.cnc_level as usize)
         + &"░".repeat((s.cnc_max - s.cnc_level) as usize);
 
+    println!("  Model        {}", dev.config().info.name);
     println!("  Battery      {}%", s.battery);
     if !s.mode.is_empty() {
         println!("  Mode         {}", s.mode);


### PR DESCRIPTION
## Summary
- Add `BOSE_DEVICES` catalog from `downloads.bose.com/lookup.xml` listing all known BMAP-capable devices — headphones, earbuds, speakers with codenames and marketing names
- Fix product ID mappings: remove incorrect `0x400C` (SoundLink Around-Ear II, not a QC35), add `0x4017` (kleos/QC35 original)
- Show device model name as first line in `bosectl status` / `bmapctl status` across all three CLIs
- Catalog serves as future coverage map — unsupported devices are recognized (`None` config) so we can incrementally add support

## Test plan
- [x] Python tests pass (101)
- [x] Rust tests pass (53)
- [x] C++ build + tests pass (43)
- [ ] Live test `bosectl status` shows model name (headphones were off at test time)