### PR TITLE
Add release artifacts and Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@
         python-setup python-test python-lint python-build python-publish \
         rust-test rust-build rust-publish \
         cpp-test cpp-build \
-        integration
+        integration \
+        artifacts release
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
@@ -80,8 +81,43 @@ test: python-test rust-test cpp-test ## Run all tests across all languages
 
 lint: python-lint ## Lint all languages
 
+# ── Release Artifacts ────────────────────────────────────────────────────────
+
+ARCH := $(shell uname -m)
+DIST = dist
+
+artifacts: rust-build cpp-build ## Build release binaries with checksums
+	@mkdir -p $(DIST)
+	cp $(RUST_DIR)/target/release/bmapctl $(DIST)/bmapctl-rust-linux-$(ARCH)
+	strip $(DIST)/bmapctl-rust-linux-$(ARCH)
+	cmake -S $(CPP_DIR) -B $(CPP_BUILD) -DCMAKE_BUILD_TYPE=Release
+	cmake --build $(CPP_BUILD) --config Release
+	cp $(CPP_BUILD)/bmapctl $(DIST)/bmapctl-cpp-linux-$(ARCH)
+	strip $(DIST)/bmapctl-cpp-linux-$(ARCH)
+	cd $(DIST) && sha256sum bmapctl-* > SHA256SUMS
+	@echo ""
+	@echo "Artifacts in $(DIST)/:"
+	@ls -lh $(DIST)/
+	@echo ""
+	@cat $(DIST)/SHA256SUMS
+
+release: test artifacts ## Run tests, build artifacts, create GitHub release
+	@if [ -z "$(VERSION)" ]; then echo "Usage: make release VERSION=v0.2.0"; exit 1; fi
+	gh release create $(VERSION) \
+		$(DIST)/bmapctl-rust-linux-$(ARCH) \
+		$(DIST)/bmapctl-cpp-linux-$(ARCH) \
+		$(DIST)/SHA256SUMS \
+		--title "$(VERSION)" \
+		--generate-notes
+	@echo ""
+	@echo "Released $(VERSION):"
+	@echo "  https://github.com/$$(gh repo view --json nameWithOwner -q .nameWithOwner)/releases/tag/$(VERSION)"
+
+# ── Cleanup ─────────────────────────────────────────────────────────────────
+
 clean: ## Remove build artifacts
 	rm -rf $(VENV) $(PYTHON_DIR)/dist $(PYTHON_DIR)/build $(PYTHON_DIR)/*.egg-info
 	rm -rf $(PYTHON_DIR)/.pytest_cache $(PYTHON_DIR)/__pycache__
 	cd $(RUST_DIR) && cargo clean 2>/dev/null || true
 	rm -rf $(CPP_BUILD)
+	rm -rf $(DIST)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -12,8 +12,21 @@ add_library(bmap STATIC
 )
 target_include_directories(bmap PUBLIC src)
 
+# Git hash for version string
+execute_process(
+    COMMAND git rev-parse --short HEAD
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/..
+    OUTPUT_VARIABLE GIT_HASH
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+)
+if(NOT GIT_HASH)
+    set(GIT_HASH "unknown")
+endif()
+
 # CLI
 add_executable(bmapctl src/main.cpp)
+target_compile_definitions(bmapctl PRIVATE GIT_HASH="${GIT_HASH}" BMAP_VERSION="${PROJECT_VERSION}")
 target_link_libraries(bmapctl PRIVATE bmap bluetooth)
 
 # Tests

--- a/cpp/src/main.cpp
+++ b/cpp/src/main.cpp
@@ -9,7 +9,7 @@
 using namespace bmap;
 
 static void usage() {
-    std::cout << "bmapctl — Control BMAP Bluetooth audio devices\n\n"
+    std::cout << "bmapctl " BMAP_VERSION " (" GIT_HASH ") — Control BMAP Bluetooth audio devices\n\n"
               << "Usage: bmapctl <command> [args...]\n\n"
               << "  status              Show all settings\n"
               << "  battery             Battery percentage\n"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -533,3 +533,104 @@ static Addr require(const std::optional<Addr>& opt, const char* name) {
 
 **Ownership**: `BmapConnection` owns the transport via `std::unique_ptr<Transport>`.
 The `connect()` function returns `std::unique_ptr<BmapConnection>`.
+
+---
+
+## Building & Testing
+
+A top-level `Makefile` orchestrates all three implementations.
+Prerequisites: Python 3, Rust/Cargo, CMake, GCC/Clang, `libbluetooth-dev`.
+
+### Quick Start
+
+```bash
+make test        # run all test suites (Python + Rust + C++)
+make artifacts   # build release binaries + SHA256SUMS
+```
+
+### Available Targets
+
+| Target | Description |
+|--------|-------------|
+| `make test` | Run all tests across all three languages |
+| `make python-test` | Python unit tests (auto-creates virtualenv) |
+| `make rust-test` | Rust tests via `cargo test` |
+| `make cpp-test` | C++ tests via CMake + ctest |
+| `make artifacts` | Build release binaries, strip, generate checksums |
+| `make release VERSION=vX.Y.Z` | Full release: test → build → `gh release create` |
+| `make clean` | Remove all build artifacts, venvs, dist/ |
+| `make integration` | Integration tests (requires paired Bluetooth device) |
+| `make help` | Show all targets |
+
+### Build Flow
+
+```mermaid
+graph LR
+    subgraph test
+        PT[python-test] --> T[test]
+        RT[rust-test] --> T
+        CT[cpp-test] --> T
+    end
+
+    subgraph artifacts
+        RB[rust-build<br/>cargo build --release] --> A[artifacts]
+        CB[cpp-build<br/>cmake Release] --> A
+        A --> STRIP[strip binaries]
+        STRIP --> SHA[SHA256SUMS]
+    end
+
+    T --> REL[release]
+    SHA --> REL
+    REL --> GH[gh release create]
+
+    style T fill:#26de81,stroke:#333,color:#fff
+    style A fill:#4a9eff,stroke:#333,color:#fff
+    style REL fill:#ff9f43,stroke:#333,color:#fff
+    style GH fill:#a55eea,stroke:#333,color:#fff
+```
+
+### Release Process
+
+```bash
+# 1. Ensure all tests pass and artifacts build
+make test
+make artifacts
+
+# 2. Create a tagged release with binaries
+make release VERSION=v0.2.0
+
+# This runs: test → artifacts → gh release create
+# Binaries are named: bmapctl-{rust,cpp}-linux-{arch}
+# SHA256SUMS is included for verification
+```
+
+### Artifact Verification
+
+```bash
+# Download and verify
+cd dist/
+sha256sum -c SHA256SUMS
+
+# Install
+chmod +x bmapctl-rust-linux-x86_64
+sudo cp bmapctl-rust-linux-x86_64 /usr/local/bin/bmapctl
+```
+
+### Language-Specific Builds
+
+Each language can be built independently:
+
+```bash
+# Python — virtualenv auto-created
+make python-setup   # create venv, install deps
+make python-test    # run pytest
+make python-build   # sdist + wheel in python/dist/
+
+# Rust
+make rust-build     # cargo build --release
+make rust-test      # cargo test
+
+# C++
+make cpp-build      # cmake + make (Debug)
+make cpp-test       # build + run bmap_tests
+```

--- a/python/pybmap/cli.py
+++ b/python/pybmap/cli.py
@@ -1,6 +1,7 @@
 """bosectl CLI — thin wrapper around the pybmap library."""
 
 import os
+import subprocess
 import sys
 
 import pybmap
@@ -32,9 +33,21 @@ _BANNER_LINES = [
     r" / /_/ / /_/ (__  )  __/ /__/ /_/ /  ",
     r"/_.___/\____/____/\___/\___/\__/_/   ",
 ]
+def _git_hash():
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            capture_output=True, text=True, timeout=2,
+        )
+        return result.stdout.strip() or "unknown"
+    except Exception:
+        return "unknown"
+
 BANNER = "\n".join(
     "%s%s%s%s" % (C_BOLD, _GRAD[i], line, C_RESET) for i, line in enumerate(_BANNER_LINES)
-) + "\n%s  Bose headphones — no app, no cloud, no account%s\n" % (C_DIM, C_RESET)
+) + "\n%s  %s (%s) — no app, no cloud, no account%s\n" % (
+    C_DIM, pybmap.__version__, _git_hash(), C_RESET
+)
 
 
 def row(label, value, color=None):

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -1,0 +1,12 @@
+use std::process::Command;
+
+fn main() {
+    let hash = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .unwrap_or_else(|| "unknown".into());
+    println!("cargo:rustc-env=GIT_HASH={}", hash.trim());
+    println!("cargo:rerun-if-changed=../.git/HEAD");
+}

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -258,7 +258,8 @@ fn hex_to_bytes(hex: &str) -> Vec<u8> {
 }
 
 fn usage() {
-    println!("bmapctl — Control BMAP Bluetooth audio devices");
+    println!("bmapctl {} ({}) — Control BMAP Bluetooth audio devices",
+             env!("CARGO_PKG_VERSION"), env!("GIT_HASH"));
     println!();
     println!("Usage: bmapctl <command> [args...]");
     println!();


### PR DESCRIPTION
## Summary
- `make artifacts` — builds Rust and C++ release binaries, strips them, generates SHA256SUMS in `dist/`
- `make release VERSION=v0.2.0` — runs all tests, builds artifacts, creates GitHub release with binaries attached
- `make clean` now also removes `dist/`

## Usage
```bash
make artifacts              # just build
make release VERSION=v0.2.0 # full release flow
```

## Test plan
- [x] `make artifacts` produces stripped binaries + SHA256SUMS
- [x] `make help` shows new targets
- [x] `make clean` removes dist/