### PR TITLE
Rewrite catalog from decompiled Bose Music APK

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,14 @@ product ID but don't have tested configurations yet — contributions welcome:
 | Device | Codename | Category | PID |
 |--------|----------|----------|-----|
 | Noise Cancelling Headphones 700 | goodyear | Headphones | `0x4024` |
-| QuietComfort 45 | vedder | Headphones | `0x4061` |
-| QuietComfort Earbuds II | olivia | Earbuds | `0x4060` |
-| QuietComfort Ultra Earbuds | prince | Earbuds | `0x4075` |
-| Ultra Open Earbuds | edith | Earbuds | `0x4063` |
-| SoundLink Flex (1st & 2nd gen) | duran / scotty | Speaker | `0x4039` / `0x4073` |
-| SoundLink Max | lonestarr | Speaker | `0x4066` |
+| QuietComfort 45 | duran | Headphones | `0x4039` |
+| QuietComfort Headphones | prince | Headphones | `0x4075` |
+| QuietComfort Ultra Headphones | lonestarr | Headphones | `0x4066` |
+| QuietComfort Earbuds II | smalls | Earbuds | `0x4064` |
+| QuietComfort Ultra Earbuds | scotty | Earbuds | `0x4072` |
+| Ultra Open Earbuds | serena | Earbuds | `0x4068` |
+| SoundLink Flex | phelps | Speaker | `0xBC59` |
+| SoundLink Flex 2 | mathers | Speaker | `0xBC61` |
 
 Adding a new device is a configuration entry — no library code changes needed.
 See [Adding a New Device](docs/architecture.md#adding-a-new-device).

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ import pybmap
 
 # Look up any known Bose device by product ID
 dev = pybmap.lookup_device(0x4082)
-print(dev.name)       # "QuietComfort Ultra Headphones"
+print(dev.name)       # "QuietComfort Ultra Headphones (2nd Gen)"
 print(dev.codename)   # "wolverine"
 
 # USB/Bluetooth identification
@@ -109,9 +109,9 @@ pybmap.modalias(0x4082)   # "bluetooth:v05A7p4082d0000"
 
 # Check support status
 pybmap.is_supported(0x4082)  # True — has tested config
-pybmap.is_supported(0x4061)  # False — QC45, recognized but untested
-pybmap.supported_devices()   # [kleos, baywolf, wolverine]
-pybmap.known_devices()       # all 14 BMAP devices
+pybmap.is_supported(0x4039)  # False — QC45, recognized but untested
+pybmap.supported_devices()   # [wolfcastle, baywolf, edith, wolverine]
+pybmap.known_devices()       # full APK-sourced catalog
 ```
 
 ## Installation

--- a/cpp/src/catalog.h
+++ b/cpp/src/catalog.h
@@ -1,5 +1,7 @@
 // Bose device catalog — known BMAP-capable devices.
-// Source: https://downloads.bose.com/lookup.xml
+// Sourced from the decompiled Bose Music APK (BoseProductId.java enum).
+// The enum's `value` field is the product ID reported over Bluetooth
+// Modalias; verified against WOLVERINE (0x4082) and EDITH (0x4062).
 #pragma once
 
 #include <cstdint>
@@ -29,22 +31,46 @@ struct BoseDevice {
 inline const std::vector<BoseDevice>& catalog() {
     static const std::vector<BoseDevice> devices = {
         // Headphones
-        {0x4017, "kleos",     "QuietComfort 35",                 Category::Headphones, "qc35"},
-        {0x4020, "baywolf",   "QuietComfort 35 II",              Category::Headphones, "qc35"},
-        {0x4024, "goodyear",  "Noise Cancelling Headphones 700", Category::Headphones, nullptr},
-        {0x4061, "vedder",    "QuietComfort 45",                 Category::Headphones, nullptr},
-        {0x4082, "wolverine", "QuietComfort Ultra Headphones",   Category::Headphones, "qc_ultra2"},
+        {0x400C, "wolfcastle", "QuietComfort 35",                         Category::Headphones, "qc35"},
+        {0x4015, "stetson",    "Hearphones",                              Category::Headphones, nullptr},
+        {0x4020, "baywolf",    "QuietComfort 35 II",                      Category::Headphones, "qc35"},
+        {0x4021, "atlas",      "ProFlight",                               Category::Headphones, nullptr},
+        {0x4024, "goodyear",   "Noise Cancelling Headphones 700",         Category::Headphones, nullptr},
+        {0x402B, "beanie",     "Hearphones II",                           Category::Headphones, nullptr},
+        {0x4039, "duran",      "QuietComfort 45",                         Category::Headphones, nullptr},
+        {0x4066, "lonestarr",  "QuietComfort Ultra Headphones",           Category::Headphones, nullptr},
+        {0x4075, "prince",     "QuietComfort Headphones",                 Category::Headphones, nullptr},
+        {0x4082, "wolverine",  "QuietComfort Ultra Headphones (2nd Gen)", Category::Headphones, "qc_ultra2"},
         // Earbuds
-        {0x4060, "olivia",    "QuietComfort Earbuds II",         Category::Earbuds, nullptr},
-        {0x4063, "edith",     "Ultra Open Earbuds",              Category::Earbuds, nullptr},
-        {0x4075, "prince",    "QuietComfort Ultra Earbuds",      Category::Earbuds, nullptr},
+        {0x4012, "ice",        "SoundSport",                              Category::Earbuds, nullptr},
+        {0x4013, "flurry",     "SoundSport Pulse",                        Category::Earbuds, nullptr},
+        {0x4014, "powder",     "QuietControl 30",                         Category::Earbuds, nullptr},
+        {0x4018, "levi",       "SoundSport Free",                         Category::Earbuds, nullptr},
+        {0x402C, "celine",     "Frames",                                  Category::Earbuds, nullptr},
+        {0x402D, "revel",      "Sport Earbuds",                           Category::Earbuds, nullptr},
+        {0x402F, "lando",      "QuietComfort Earbuds",                    Category::Earbuds, nullptr},
+        {0x403A, "gwen",       "Sport Open Earbuds",                      Category::Earbuds, nullptr},
+        {0x404C, "celine_ii",  "Frames (2nd Gen)",                        Category::Earbuds, nullptr},
+        {0x4060, "olivia",     "Frames Tempo",                            Category::Earbuds, nullptr},
+        {0x4061, "vedder",     "Frames",                                  Category::Earbuds, nullptr},
+        {0x4062, "edith",      "QuietComfort Ultra Earbuds (2nd Gen)",    Category::Earbuds, "qc_ultra2"},
+        {0x4064, "smalls",     "QuietComfort Earbuds II",                 Category::Earbuds, nullptr},
+        {0x4068, "serena",     "Ultra Open Earbuds",                      Category::Earbuds, nullptr},
+        {0x4072, "scotty",     "QuietComfort Ultra Earbuds",              Category::Earbuds, nullptr},
         // Speakers
-        {0x402D, "revel",     "Home Speaker 300",                Category::Speaker, nullptr},
-        {0x402F, "lando",     "Portable Home Speaker",           Category::Speaker, nullptr},
-        {0x4039, "duran",     "SoundLink Flex",                  Category::Speaker, nullptr},
-        {0x403A, "gwen",      "SoundLink Revolve+ II",           Category::Speaker, nullptr},
-        {0x4066, "lonestarr", "SoundLink Max",                   Category::Speaker, nullptr},
-        {0x4073, "scotty",    "SoundLink Flex 2nd Gen",          Category::Speaker, nullptr},
+        {0x400A, "isaac",      "AE2 SoundLink",                           Category::Speaker, nullptr},
+        {0x400D, "foreman",    "SoundLink Color II",                      Category::Speaker, nullptr},
+        {0x4010, "folgers",    "SoundLink Revolve",                       Category::Speaker, nullptr},
+        {0x4011, "harvey",     "SoundLink Revolve+",                      Category::Speaker, nullptr},
+        {0x4017, "kleos",      "SoundWear",                               Category::Speaker, nullptr},
+        {0x4022, "minnow",     "SoundLink Micro",                         Category::Speaker, nullptr},
+        {0x4085, "troy",       "SoundLink Plus",                          Category::Speaker, nullptr},
+        {0xA211, "chibi",      "S1 Pro",                                  Category::Speaker, nullptr},
+        {0xBC58, "billie",     "SoundLink Micro 2",                       Category::Speaker, nullptr},
+        {0xBC59, "phelps",     "SoundLink Flex",                          Category::Speaker, nullptr},
+        {0xBC60, "phelps_ii",  "SoundLink Flex (2nd Gen)",                Category::Speaker, nullptr},
+        {0xBC61, "mathers",    "SoundLink Flex 2",                        Category::Speaker, nullptr},
+        {0xBC63, "stan",       "SoundLink Flex SE 2",                     Category::Speaker, nullptr},
     };
     return devices;
 }

--- a/cpp/tests/test_catalog.cpp
+++ b/cpp/tests/test_catalog.cpp
@@ -20,9 +20,19 @@ TEST(catalog_lookup_qc35) {
 }
 
 TEST(catalog_lookup_qc35_original) {
-    auto* dev = lookup_device(0x4017);
+    auto* dev = lookup_device(0x400C);
     ASSERT_TRUE(dev != nullptr);
-    ASSERT_EQ(std::string(dev->codename), std::string("kleos"));
+    ASSERT_EQ(std::string(dev->codename), std::string("wolfcastle"));
+    ASSERT_TRUE(dev->config != nullptr);
+    ASSERT_EQ(std::string(dev->config), std::string("qc35"));
+}
+
+TEST(catalog_lookup_qc_ultra2_earbuds) {
+    auto* dev = lookup_device(0x4062);
+    ASSERT_TRUE(dev != nullptr);
+    ASSERT_EQ(std::string(dev->codename), std::string("edith"));
+    ASSERT_TRUE(dev->config != nullptr);
+    ASSERT_EQ(std::string(dev->config), std::string("qc_ultra2"));
 }
 
 TEST(catalog_lookup_unknown) {

--- a/cpp/tests/test_catalog.cpp
+++ b/cpp/tests/test_catalog.cpp
@@ -48,7 +48,7 @@ TEST(catalog_is_supported) {
 
 TEST(catalog_supported_devices) {
     auto devs = supported_devices();
-    ASSERT_TRUE(devs.size() >= 3u);
+    ASSERT_TRUE(devs.size() >= 4u);  // wolfcastle, baywolf, edith, wolverine
     for (auto* d : devs) {
         ASSERT_TRUE(d->config != nullptr);
     }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -322,7 +322,7 @@ Each catalog entry carries:
 |-------|-------------|---------|
 | `product_id` | USB PID / Bluetooth Modalias ID | `0x4082` |
 | `codename` | Bose internal codename | `"wolverine"` |
-| `name` | Marketing product name | `"QuietComfort Ultra Headphones"` |
+| `name` | Marketing product name | `"QuietComfort Ultra Headphones (2nd Gen)"` |
 | `category` | `headphones`, `earbuds`, or `speaker` | `headphones` |
 | `config` | Library config key, or None | `"qc_ultra2"` |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -329,17 +329,20 @@ Each catalog entry carries:
 **Public API** (identical across all three libraries):
 
 ```
-lookup_device(0x4082)    → BoseDevice{wolverine, "QC Ultra Headphones", config="qc_ultra2"}
+lookup_device(0x4082)    → BoseDevice{wolverine, "QuietComfort Ultra Headphones (2nd Gen)", config="qc_ultra2"}
 is_supported(0x4024)     → False (NCH 700: recognized, no config yet)
-supported_devices()      → [kleos, baywolf, wolverine]
-known_devices()          → all 14 entries
+supported_devices()      → [wolfcastle, baywolf, edith, wolverine]
+known_devices()          → full APK-sourced catalog
 usb_ids(0x4082)          → (0x05A7, 0x4082)
 modalias(0x4082)         → "bluetooth:v05A7p4082d0000"
 ```
 
-The USB vendor ID `0x05A7` is shared by all Bose devices. The product ID
-appears in both USB descriptors (DFU mode) and Bluetooth Modalias strings
-(normal mode), making it the universal device identifier.
+The USB vendor ID `0x05A7` is shared by all Bose devices. The catalog
+is sourced from the decompiled Bose Music APK (`BoseProductId.java`
+enum) — the enum's `value` field is what the device reports in the
+Bluetooth Modalias string. Note that USB DFU PIDs (as listed by
+projects like bose-dfu) are a **different ID space** and should not be
+conflated with BT Modalias PIDs.
 
 Discovery uses the catalog to resolve product IDs to config keys. Devices
 with `config=None` are recognized (logged, not errored) but fall back to
@@ -349,21 +352,16 @@ a default config since they don't have a tested implementation yet.
 
 | PID | Codename | Product | Config |
 |-----|----------|---------|--------|
-| `0x4017` | kleos | QuietComfort 35 | `qc35` |
+| `0x400C` | wolfcastle | QuietComfort 35 | `qc35` |
 | `0x4020` | baywolf | QuietComfort 35 II | `qc35` |
-| `0x4082` | wolverine | QuietComfort Ultra Headphones | `qc_ultra2` |
+| `0x4062` | edith | QuietComfort Ultra Earbuds (2nd Gen) | `qc_ultra2` |
+| `0x4082` | wolverine | QuietComfort Ultra Headphones (2nd Gen) | `qc_ultra2` |
 
 ### Known Unsupported (Future Targets)
 
-| PID | Codename | Product | Category |
-|-----|----------|---------|----------|
-| `0x4024` | goodyear | Noise Cancelling Headphones 700 | headphones |
-| `0x4061` | vedder | QuietComfort 45 | headphones |
-| `0x4060` | olivia | QuietComfort Earbuds II | earbuds |
-| `0x4063` | edith | Ultra Open Earbuds | earbuds |
-| `0x4075` | prince | QuietComfort Ultra Earbuds | earbuds |
-| `0x4039` | duran | SoundLink Flex | speaker |
-| `0x4073` | scotty | SoundLink Flex 2nd Gen | speaker |
+See `catalog.py` / `catalog.rs` / `catalog.h` for the full APK-sourced
+device list. Entries with `config=None` are recognized but not yet
+implemented.
 
 ## Adding a New Device
 

--- a/python/pybmap/catalog.py
+++ b/python/pybmap/catalog.py
@@ -25,30 +25,57 @@ BoseDevice = namedtuple("BoseDevice", [
 
 
 # ── Device Catalog ──────────────────────────────────────────────────────────
-# All known BMAP-capable Bose devices. Entries with config=None are
-# recognized but not yet supported — they serve as a roadmap for
-# future protocol implementations.
+# Sourced from the decompiled Bose Music APK (BoseProductId.java enum).
+# The enum's `value` field is the product ID reported over Bluetooth
+# Modalias; verified against WOLVERINE (0x4082) and EDITH (0x4062).
+#
+# Entries with config=None are recognized but not yet supported — they
+# serve as a roadmap for future protocol implementations.
 
 CATALOG = {
     # Headphones
-    0x4017: BoseDevice(0x4017, "kleos",     "QuietComfort 35",                "headphones", "qc35"),
-    0x4020: BoseDevice(0x4020, "baywolf",   "QuietComfort 35 II",             "headphones", "qc35"),
-    0x4024: BoseDevice(0x4024, "goodyear",  "Noise Cancelling Headphones 700","headphones", None),
-    0x4061: BoseDevice(0x4061, "vedder",    "QuietComfort 45",                "headphones", None),
-    0x4082: BoseDevice(0x4082, "wolverine", "QuietComfort Ultra Headphones",  "headphones", "qc_ultra2"),
+    0x400C: BoseDevice(0x400C, "wolfcastle", "QuietComfort 35",                      "headphones", "qc35"),
+    0x4015: BoseDevice(0x4015, "stetson",    "Hearphones",                           "headphones", None),
+    0x4020: BoseDevice(0x4020, "baywolf",    "QuietComfort 35 II",                   "headphones", "qc35"),
+    0x4021: BoseDevice(0x4021, "atlas",      "ProFlight",                            "headphones", None),
+    0x4024: BoseDevice(0x4024, "goodyear",   "Noise Cancelling Headphones 700",      "headphones", None),
+    0x402B: BoseDevice(0x402B, "beanie",     "Hearphones II",                        "headphones", None),
+    0x4039: BoseDevice(0x4039, "duran",      "QuietComfort 45",                      "headphones", None),
+    0x4066: BoseDevice(0x4066, "lonestarr",  "QuietComfort Ultra Headphones",        "headphones", None),
+    0x4075: BoseDevice(0x4075, "prince",     "QuietComfort Headphones",              "headphones", None),
+    0x4082: BoseDevice(0x4082, "wolverine",  "QuietComfort Ultra Headphones (2nd Gen)", "headphones", "qc_ultra2"),
 
     # Earbuds
-    0x4060: BoseDevice(0x4060, "olivia",    "QuietComfort Earbuds II",        "earbuds", None),
-    0x4063: BoseDevice(0x4063, "edith",     "Ultra Open Earbuds",             "earbuds", None),
-    0x4075: BoseDevice(0x4075, "prince",    "QuietComfort Ultra Earbuds",     "earbuds", None),
+    0x4012: BoseDevice(0x4012, "ice",        "SoundSport",                           "earbuds", None),
+    0x4013: BoseDevice(0x4013, "flurry",     "SoundSport Pulse",                     "earbuds", None),
+    0x4014: BoseDevice(0x4014, "powder",     "QuietControl 30",                      "earbuds", None),
+    0x4018: BoseDevice(0x4018, "levi",       "SoundSport Free",                      "earbuds", None),
+    0x402C: BoseDevice(0x402C, "celine",     "Frames",                               "earbuds", None),
+    0x402D: BoseDevice(0x402D, "revel",      "Sport Earbuds",                        "earbuds", None),
+    0x402F: BoseDevice(0x402F, "lando",      "QuietComfort Earbuds",                 "earbuds", None),
+    0x403A: BoseDevice(0x403A, "gwen",       "Sport Open Earbuds",                   "earbuds", None),
+    0x404C: BoseDevice(0x404C, "celine_ii",  "Frames (2nd Gen)",                     "earbuds", None),
+    0x4060: BoseDevice(0x4060, "olivia",     "Frames Tempo",                         "earbuds", None),
+    0x4061: BoseDevice(0x4061, "vedder",     "Frames",                               "earbuds", None),
+    0x4062: BoseDevice(0x4062, "edith",      "QuietComfort Ultra Earbuds (2nd Gen)", "earbuds", "qc_ultra2"),
+    0x4064: BoseDevice(0x4064, "smalls",     "QuietComfort Earbuds II",              "earbuds", None),
+    0x4068: BoseDevice(0x4068, "serena",     "Ultra Open Earbuds",                   "earbuds", None),
+    0x4072: BoseDevice(0x4072, "scotty",     "QuietComfort Ultra Earbuds",           "earbuds", None),
 
     # Speakers
-    0x402D: BoseDevice(0x402D, "revel",     "Home Speaker 300",               "speaker", None),
-    0x402F: BoseDevice(0x402F, "lando",     "Portable Home Speaker",          "speaker", None),
-    0x4039: BoseDevice(0x4039, "duran",     "SoundLink Flex",                 "speaker", None),
-    0x403A: BoseDevice(0x403A, "gwen",      "SoundLink Revolve+ II",          "speaker", None),
-    0x4066: BoseDevice(0x4066, "lonestarr", "SoundLink Max",                  "speaker", None),
-    0x4073: BoseDevice(0x4073, "scotty",    "SoundLink Flex 2nd Gen",         "speaker", None),
+    0x400A: BoseDevice(0x400A, "isaac",      "AE2 SoundLink",                        "speaker", None),
+    0x400D: BoseDevice(0x400D, "foreman",    "SoundLink Color II",                   "speaker", None),
+    0x4010: BoseDevice(0x4010, "folgers",    "SoundLink Revolve",                    "speaker", None),
+    0x4011: BoseDevice(0x4011, "harvey",     "SoundLink Revolve+",                   "speaker", None),
+    0x4017: BoseDevice(0x4017, "kleos",      "SoundWear",                            "speaker", None),
+    0x4022: BoseDevice(0x4022, "minnow",     "SoundLink Micro",                      "speaker", None),
+    0x4085: BoseDevice(0x4085, "troy",       "SoundLink Plus",                       "speaker", None),
+    0xA211: BoseDevice(0xA211, "chibi",      "S1 Pro",                               "speaker", None),
+    0xBC58: BoseDevice(0xBC58, "billie",     "SoundLink Micro 2",                    "speaker", None),
+    0xBC59: BoseDevice(0xBC59, "phelps",     "SoundLink Flex",                       "speaker", None),
+    0xBC60: BoseDevice(0xBC60, "phelps_ii",  "SoundLink Flex (2nd Gen)",             "speaker", None),
+    0xBC61: BoseDevice(0xBC61, "mathers",    "SoundLink Flex 2",                     "speaker", None),
+    0xBC63: BoseDevice(0xBC63, "stan",       "SoundLink Flex SE 2",                  "speaker", None),
 }
 
 

--- a/python/pybmap/catalog.py
+++ b/python/pybmap/catalog.py
@@ -1,6 +1,8 @@
 """Bose device catalog — known BMAP-capable devices.
 
-Source: https://downloads.bose.com/lookup.xml
+Sourced from the decompiled Bose Music APK (BoseProductId.java enum).
+The enum's `value` field is the product ID reported over Bluetooth
+Modalias; verified against WOLVERINE (0x4082) and EDITH (0x4062).
 USB VID 0x05a7 is shared by all Bose devices.
 
 This module is the authoritative device registry. Discovery and

--- a/python/tests/test_catalog.py
+++ b/python/tests/test_catalog.py
@@ -12,7 +12,7 @@ class TestLookup:
         dev = lookup_device(0x4082)
         assert dev is not None
         assert dev.codename == "wolverine"
-        assert dev.name == "QuietComfort Ultra Headphones"
+        assert dev.name == "QuietComfort Ultra Headphones (2nd Gen)"
         assert dev.config == "qc_ultra2"
 
     def test_qc35(self):
@@ -21,9 +21,14 @@ class TestLookup:
         assert dev.config == "qc35"
 
     def test_qc35_original(self):
-        dev = lookup_device(0x4017)
-        assert dev.codename == "kleos"
+        dev = lookup_device(0x400C)
+        assert dev.codename == "wolfcastle"
         assert dev.config == "qc35"
+
+    def test_qc_ultra2_earbuds(self):
+        dev = lookup_device(0x4062)
+        assert dev.codename == "edith"
+        assert dev.config == "qc_ultra2"
 
     def test_unsupported_known(self):
         dev = lookup_device(0x4024)
@@ -37,9 +42,10 @@ class TestLookup:
 
 class TestSupport:
     def test_is_supported(self):
-        assert is_supported(0x4082)
-        assert is_supported(0x4020)
-        assert is_supported(0x4017)
+        assert is_supported(0x4082)  # wolverine
+        assert is_supported(0x4062)  # edith
+        assert is_supported(0x4020)  # baywolf
+        assert is_supported(0x400C)  # wolfcastle
 
     def test_not_supported(self):
         assert not is_supported(0x4024)  # NCH 700
@@ -47,7 +53,7 @@ class TestSupport:
 
     def test_supported_devices(self):
         devs = supported_devices()
-        assert len(devs) >= 3  # kleos, baywolf, wolverine
+        assert len(devs) >= 4  # wolfcastle, baywolf, edith, wolverine
         assert all(d.config is not None for d in devs)
 
     def test_known_devices(self):

--- a/rust/src/catalog.rs
+++ b/rust/src/catalog.rs
@@ -116,6 +116,21 @@ mod tests {
     fn test_lookup_known() {
         let dev = lookup_device(0x4082).unwrap();
         assert_eq!(dev.codename, "wolverine");
+        assert_eq!(dev.name, "QuietComfort Ultra Headphones (2nd Gen)");
+        assert_eq!(dev.config, Some("qc_ultra2"));
+    }
+
+    #[test]
+    fn test_lookup_qc35_original() {
+        let dev = lookup_device(0x400C).unwrap();
+        assert_eq!(dev.codename, "wolfcastle");
+        assert_eq!(dev.config, Some("qc35"));
+    }
+
+    #[test]
+    fn test_lookup_qc_ultra2_earbuds() {
+        let dev = lookup_device(0x4062).unwrap();
+        assert_eq!(dev.codename, "edith");
         assert_eq!(dev.config, Some("qc_ultra2"));
     }
 
@@ -126,8 +141,10 @@ mod tests {
 
     #[test]
     fn test_is_supported() {
-        assert!(is_supported(0x4082));
-        assert!(is_supported(0x4020));
+        assert!(is_supported(0x4082)); // wolverine
+        assert!(is_supported(0x4062)); // edith
+        assert!(is_supported(0x4020)); // baywolf
+        assert!(is_supported(0x400C)); // wolfcastle
         assert!(!is_supported(0x4024)); // NCH 700, no config
         assert!(!is_supported(0xFFFF));
     }
@@ -135,7 +152,7 @@ mod tests {
     #[test]
     fn test_supported_devices() {
         let devs = supported_devices();
-        assert!(devs.len() >= 2); // at least QC35 + QC Ultra 2
+        assert!(devs.len() >= 4); // wolfcastle, baywolf, edith, wolverine
         assert!(devs.iter().all(|d| d.config.is_some()));
     }
 

--- a/rust/src/catalog.rs
+++ b/rust/src/catalog.rs
@@ -1,6 +1,9 @@
 //! Bose device catalog — known BMAP-capable devices.
 //!
-//! Source: <https://downloads.bose.com/lookup.xml>
+//! Sourced from the decompiled Bose Music APK (`BoseProductId.java`
+//! enum). The enum's `value` field is the product ID reported over
+//! Bluetooth Modalias; verified against WOLVERINE (0x4082) and EDITH
+//! (0x4062).
 
 /// All Bose USB devices share this vendor ID.
 pub const BOSE_USB_VID: u16 = 0x05A7;
@@ -30,22 +33,46 @@ pub struct BoseDevice {
 /// All known BMAP-capable Bose devices.
 pub const CATALOG: &[BoseDevice] = &[
     // Headphones
-    BoseDevice { product_id: 0x4017, codename: "kleos",     name: "QuietComfort 35",                 category: Category::Headphones, config: Some("qc35") },
-    BoseDevice { product_id: 0x4020, codename: "baywolf",   name: "QuietComfort 35 II",              category: Category::Headphones, config: Some("qc35") },
-    BoseDevice { product_id: 0x4024, codename: "goodyear",  name: "Noise Cancelling Headphones 700", category: Category::Headphones, config: None },
-    BoseDevice { product_id: 0x4061, codename: "vedder",    name: "QuietComfort 45",                 category: Category::Headphones, config: None },
-    BoseDevice { product_id: 0x4082, codename: "wolverine", name: "QuietComfort Ultra Headphones",   category: Category::Headphones, config: Some("qc_ultra2") },
+    BoseDevice { product_id: 0x400C, codename: "wolfcastle", name: "QuietComfort 35",                        category: Category::Headphones, config: Some("qc35") },
+    BoseDevice { product_id: 0x4015, codename: "stetson",    name: "Hearphones",                             category: Category::Headphones, config: None },
+    BoseDevice { product_id: 0x4020, codename: "baywolf",    name: "QuietComfort 35 II",                     category: Category::Headphones, config: Some("qc35") },
+    BoseDevice { product_id: 0x4021, codename: "atlas",      name: "ProFlight",                              category: Category::Headphones, config: None },
+    BoseDevice { product_id: 0x4024, codename: "goodyear",   name: "Noise Cancelling Headphones 700",        category: Category::Headphones, config: None },
+    BoseDevice { product_id: 0x402B, codename: "beanie",     name: "Hearphones II",                          category: Category::Headphones, config: None },
+    BoseDevice { product_id: 0x4039, codename: "duran",      name: "QuietComfort 45",                        category: Category::Headphones, config: None },
+    BoseDevice { product_id: 0x4066, codename: "lonestarr",  name: "QuietComfort Ultra Headphones",          category: Category::Headphones, config: None },
+    BoseDevice { product_id: 0x4075, codename: "prince",     name: "QuietComfort Headphones",                category: Category::Headphones, config: None },
+    BoseDevice { product_id: 0x4082, codename: "wolverine",  name: "QuietComfort Ultra Headphones (2nd Gen)", category: Category::Headphones, config: Some("qc_ultra2") },
     // Earbuds
-    BoseDevice { product_id: 0x4060, codename: "olivia",    name: "QuietComfort Earbuds II",         category: Category::Earbuds, config: None },
-    BoseDevice { product_id: 0x4063, codename: "edith",     name: "Ultra Open Earbuds",              category: Category::Earbuds, config: None },
-    BoseDevice { product_id: 0x4075, codename: "prince",    name: "QuietComfort Ultra Earbuds",      category: Category::Earbuds, config: None },
+    BoseDevice { product_id: 0x4012, codename: "ice",        name: "SoundSport",                             category: Category::Earbuds, config: None },
+    BoseDevice { product_id: 0x4013, codename: "flurry",     name: "SoundSport Pulse",                       category: Category::Earbuds, config: None },
+    BoseDevice { product_id: 0x4014, codename: "powder",     name: "QuietControl 30",                        category: Category::Earbuds, config: None },
+    BoseDevice { product_id: 0x4018, codename: "levi",       name: "SoundSport Free",                        category: Category::Earbuds, config: None },
+    BoseDevice { product_id: 0x402C, codename: "celine",     name: "Frames",                                 category: Category::Earbuds, config: None },
+    BoseDevice { product_id: 0x402D, codename: "revel",      name: "Sport Earbuds",                          category: Category::Earbuds, config: None },
+    BoseDevice { product_id: 0x402F, codename: "lando",      name: "QuietComfort Earbuds",                   category: Category::Earbuds, config: None },
+    BoseDevice { product_id: 0x403A, codename: "gwen",       name: "Sport Open Earbuds",                     category: Category::Earbuds, config: None },
+    BoseDevice { product_id: 0x404C, codename: "celine_ii",  name: "Frames (2nd Gen)",                       category: Category::Earbuds, config: None },
+    BoseDevice { product_id: 0x4060, codename: "olivia",     name: "Frames Tempo",                           category: Category::Earbuds, config: None },
+    BoseDevice { product_id: 0x4061, codename: "vedder",     name: "Frames",                                 category: Category::Earbuds, config: None },
+    BoseDevice { product_id: 0x4062, codename: "edith",      name: "QuietComfort Ultra Earbuds (2nd Gen)",   category: Category::Earbuds, config: Some("qc_ultra2") },
+    BoseDevice { product_id: 0x4064, codename: "smalls",     name: "QuietComfort Earbuds II",                category: Category::Earbuds, config: None },
+    BoseDevice { product_id: 0x4068, codename: "serena",     name: "Ultra Open Earbuds",                     category: Category::Earbuds, config: None },
+    BoseDevice { product_id: 0x4072, codename: "scotty",     name: "QuietComfort Ultra Earbuds",             category: Category::Earbuds, config: None },
     // Speakers
-    BoseDevice { product_id: 0x402D, codename: "revel",     name: "Home Speaker 300",                category: Category::Speaker, config: None },
-    BoseDevice { product_id: 0x402F, codename: "lando",     name: "Portable Home Speaker",           category: Category::Speaker, config: None },
-    BoseDevice { product_id: 0x4039, codename: "duran",     name: "SoundLink Flex",                  category: Category::Speaker, config: None },
-    BoseDevice { product_id: 0x403A, codename: "gwen",      name: "SoundLink Revolve+ II",           category: Category::Speaker, config: None },
-    BoseDevice { product_id: 0x4066, codename: "lonestarr", name: "SoundLink Max",                   category: Category::Speaker, config: None },
-    BoseDevice { product_id: 0x4073, codename: "scotty",    name: "SoundLink Flex 2nd Gen",          category: Category::Speaker, config: None },
+    BoseDevice { product_id: 0x400A, codename: "isaac",      name: "AE2 SoundLink",                          category: Category::Speaker, config: None },
+    BoseDevice { product_id: 0x400D, codename: "foreman",    name: "SoundLink Color II",                     category: Category::Speaker, config: None },
+    BoseDevice { product_id: 0x4010, codename: "folgers",    name: "SoundLink Revolve",                      category: Category::Speaker, config: None },
+    BoseDevice { product_id: 0x4011, codename: "harvey",     name: "SoundLink Revolve+",                     category: Category::Speaker, config: None },
+    BoseDevice { product_id: 0x4017, codename: "kleos",      name: "SoundWear",                              category: Category::Speaker, config: None },
+    BoseDevice { product_id: 0x4022, codename: "minnow",     name: "SoundLink Micro",                        category: Category::Speaker, config: None },
+    BoseDevice { product_id: 0x4085, codename: "troy",       name: "SoundLink Plus",                         category: Category::Speaker, config: None },
+    BoseDevice { product_id: 0xA211, codename: "chibi",      name: "S1 Pro",                                 category: Category::Speaker, config: None },
+    BoseDevice { product_id: 0xBC58, codename: "billie",     name: "SoundLink Micro 2",                      category: Category::Speaker, config: None },
+    BoseDevice { product_id: 0xBC59, codename: "phelps",     name: "SoundLink Flex",                         category: Category::Speaker, config: None },
+    BoseDevice { product_id: 0xBC60, codename: "phelps_ii",  name: "SoundLink Flex (2nd Gen)",               category: Category::Speaker, config: None },
+    BoseDevice { product_id: 0xBC61, codename: "mathers",    name: "SoundLink Flex 2",                       category: Category::Speaker, config: None },
+    BoseDevice { product_id: 0xBC63, codename: "stan",       name: "SoundLink Flex SE 2",                    category: Category::Speaker, config: None },
 ];
 
 /// Look up a Bose device by product ID.


### PR DESCRIPTION
## Summary

- Rewrites the device catalog (Python / Rust / C++) using `io.intrepid.bose_bmap.model.enums.BoseProductId` from the decompiled Bose Music APK as the authoritative source.
- Expands from 14 → 39 entries and corrects several misattributed PIDs that were inherited from `bose-dfu` / `downloads.bose.com/lookup.xml` (those use different ID spaces — USB DFU PIDs and firmware lookup codes aren't BT Modalias PIDs).
- Adds `0x4062 edith "QuietComfort Ultra Earbuds (2nd Gen)"` with `qc_ultra2` config, verified by the reporter in #13.

## Why it matters

Prior catalog mappings were wrong for most entries — only WOLVERINE (`0x4082`) and BAYWOLF (`0x4020`) matched the APK. Notable corrections:

| PID | Was | Now (APK) |
|---|---|---|
| `0x4017` | kleos / QuietComfort 35 | kleos / SoundWear (neck speaker) |
| `0x4060` | olivia / QC Earbuds II | olivia / Frames Tempo |
| `0x4061` | vedder / QC 45 | vedder / Frames |
| `0x4063` | edith / Ultra Open Earbuds | (removed — it's EDITH_CHARGING_CASE) |
| `0x4075` | prince / QC Ultra Earbuds | prince / QuietComfort Headphones |
| `0x4039` | duran / SoundLink Flex | duran / QuietComfort 45 |
| `0x403A` | gwen / SoundLink Revolve+ II | gwen / Sport Open Earbuds |
| `0x402F` | lando / Portable Home Speaker | lando / QC Earbuds |
| `0x402D` | revel / Home Speaker 300 | revel / Sport Earbuds |
| `0x4066` | lonestarr / SoundLink Max | lonestarr / QC Ultra Headphones |
| `0x4073` | scotty / SoundLink Flex 2nd Gen | (removed — it's SCOTTY_CHARGING_CASE; real scotty earbuds is `0x4072`) |

New additions include WOLFCASTLE (original QC35), SCOTTY (original QC Ultra Earbuds), SERENA (Ultra Open Earbuds), EDITH (QC Ultra 2 Earbuds), plus the full Frames / SoundSport / SoundLink lineups for recognition-only detection.

## Config support

Only entries with a corroborated protocol path carry a `config` key:

| PID | Codename | Product | Config |
|---|---|---|---|
| `0x400C` | wolfcastle | QuietComfort 35 | `qc35` (new, same family as baywolf) |
| `0x4020` | baywolf | QuietComfort 35 II | `qc35` (unchanged, verified) |
| `0x4062` | edith | QC Ultra Earbuds (2nd Gen) | `qc_ultra2` (new, verified by #13) |
| `0x4082` | wolverine | QC Ultra Headphones (2nd Gen) | `qc_ultra2` (unchanged, verified) |

Closes #13 — the reporter's QC Ultra Earbuds (Gen 2) will now auto-discover with the `qc_ultra2` config, no manual `--device` flag needed.

## Test plan

- [x] Python: `pytest` — 120 passed, 18 skipped
- [x] Rust: `cargo test` — 60 passed
- [x] C++: `bmap_tests` — 52 passed
- [x] Docs updated (`README.md`, `docs/architecture.md`) to reflect new supported list and call out the DFU/Modalias PID-space distinction
- [ ] @stevenart to confirm auto-detection on merged build