### PR TITLE
Add QC45 (QuietComfort 45) device support

### DIFF
--- a/python/pybmap/catalog.py
+++ b/python/pybmap/catalog.py
@@ -42,7 +42,7 @@ CATALOG = {
     0x4021: BoseDevice(0x4021, "atlas",      "ProFlight",                            "headphones", None),
     0x4024: BoseDevice(0x4024, "goodyear",   "Noise Cancelling Headphones 700",      "headphones", None),
     0x402B: BoseDevice(0x402B, "beanie",     "Hearphones II",                        "headphones", None),
-    0x4039: BoseDevice(0x4039, "duran",      "QuietComfort 45",                      "headphones", None),
+    0x4039: BoseDevice(0x4039, "duran",      "QuietComfort 45",                      "headphones", "qc45"),
     0x4066: BoseDevice(0x4066, "lonestarr",  "QuietComfort Ultra Headphones",        "headphones", None),
     0x4075: BoseDevice(0x4075, "prince",     "QuietComfort Headphones",              "headphones", None),
     0x4082: BoseDevice(0x4082, "wolverine",  "QuietComfort Ultra Headphones (2nd Gen)", "headphones", "qc_ultra2"),

--- a/python/pybmap/connection.py
+++ b/python/pybmap/connection.py
@@ -286,12 +286,28 @@ class BmapConnection:
         """Set noise cancellation level (0-10).
 
         Scale is inverted: 0 = maximum ANC (blocks most outside sounds),
-        10 = most ambient pass-through. The effect is only audible when
-        anc_toggle=on AND wind_block=off — wind block masks CNC changes.
+        10 = most ambient pass-through.
+
+        Uses [31.10] AudioSettings if available (QC Ultra 2), otherwise
+        modifies the current editable mode via [31.6] ModeConfig SETGET
+        and switches to it (QC45).
         """
         if not 0 <= level <= 10:
             raise ValueError("CNC level must be 0-10, got %d" % level)
-        self._update_audio_settings(cnc_level=level)
+        if self.has_feature("audio_settings"):
+            self._update_audio_settings(cnc_level=level)
+        elif self.has_feature("mode_config"):
+            self._set_cnc_via_mode_config(level)
+        else:
+            raise BmapError("Device does not support CNC level control")
+
+    def _set_cnc_via_mode_config(self, level):
+        """Set CNC by writing to an editable mode and switching to it."""
+        slot, config = self._ensure_editable_profile()
+        self._write_mode_from_config(slot, config, cnc_level=level)
+        current = self.mode_idx()
+        if current != slot:
+            self._start("current_mode", bytes([slot, 0]))
 
     def set_anc(self, enabled):
         """Toggle Active Noise Cancellation on/off (bool)."""

--- a/python/pybmap/devices/__init__.py
+++ b/python/pybmap/devices/__init__.py
@@ -2,16 +2,19 @@
 
 from . import qc_ultra2
 from . import qc35
+from . import qc45
 
 # Registry of supported devices keyed by type string.
 DEVICES = {
     "qc_ultra2": qc_ultra2,
     "qc35": qc35,
+    "qc45": qc45,
 }
 
 # Product ID -> device type (for auto-detection after connecting).
 PRODUCT_IDS = {
     0x4082: "qc_ultra2",
+    0x4039: "qc45",
     # TODO: add QC35 product ID once verified
 }
 

--- a/python/pybmap/devices/parsers.py
+++ b/python/pybmap/devices/parsers.py
@@ -350,3 +350,80 @@ def build_mode_config_40(mode_idx, name, cnc_level=0, auto_cnc=False,
     payload.append(1 if wind_block else 0)
     payload.append(1 if anc_toggle else 0)
     return bytes(payload)
+
+
+def parse_mode_config_47(payload):
+    """Parse ModeConfig STATUS (47 bytes) — QC45 / CSR8670 firmware.
+
+    STATUS layout (47 bytes, no ancToggle vs QC Ultra 2's 48):
+        [0]     modeIndex
+        [1:3]   voicePrompt
+        [3:6]   flags: [3]=editable, [4]=configured, [5]=unknown
+        [6:38]  modeName (32 bytes)
+        [38:40] unknown
+        [40:42] unknown
+        [42]    cncLevel
+        [43]    autoCNC
+        [44]    spatial
+        [45]    windBlock
+        [46]    unknown
+    """
+    if len(payload) < 6:
+        return None
+
+    mode_idx = payload[0]
+    prompt_b1, prompt_b2 = payload[1], payload[2]
+    prompt_name = PROMPTS.get((prompt_b1, prompt_b2), "(%d,%d)" % (prompt_b1, prompt_b2))
+
+    if len(payload) >= 47:
+        editable = bool(payload[3])
+        configured = bool(payload[4])
+        flags = "%02x %02x %02x" % (payload[3], payload[4], payload[5])
+        name = payload[6:38].split(b"\x00", 1)[0].decode("utf-8", errors="replace")
+        return ModeConfig(
+            mode_idx=mode_idx, prompt=prompt_name,
+            prompt_bytes=(prompt_b1, prompt_b2), name=name,
+            cnc_level=payload[42], auto_cnc=bool(payload[43]),
+            spatial=payload[44], wind_block=bool(payload[45]),
+            anc_toggle=False,
+            editable=editable, configured=configured, flags=flags, raw=payload,
+        )
+    elif len(payload) >= 39:
+        name = payload[3:35].split(b"\x00", 1)[0].decode("utf-8", errors="replace")
+        return ModeConfig(
+            mode_idx=mode_idx, prompt=prompt_name,
+            prompt_bytes=(prompt_b1, prompt_b2), name=name,
+            cnc_level=payload[35], auto_cnc=bool(payload[36]),
+            spatial=payload[37], wind_block=bool(payload[38]),
+            anc_toggle=False,
+            editable=True, configured=True, flags="", raw=payload,
+        )
+    else:
+        name = (payload[3:35] if len(payload) >= 35 else payload[3:])
+        name = name.split(b"\x00", 1)[0].decode("utf-8", errors="replace")
+        return ModeConfig(
+            mode_idx=mode_idx, prompt=prompt_name,
+            prompt_bytes=(prompt_b1, prompt_b2), name=name,
+            cnc_level=0, auto_cnc=False, spatial=0,
+            wind_block=False, anc_toggle=False,
+            editable=False, configured=False, flags="", raw=payload,
+        )
+
+
+def build_mode_config_39(mode_idx, name, cnc_level=0, auto_cnc=False,
+                         spatial=0, wind_block=0,
+                         prompt_b1=0, prompt_b2=0):
+    """Build 39-byte ModeConfig SETGET payload — QC45 / CSR8670 firmware.
+
+    Same as QC Ultra 2's 40-byte format but without the ancToggle byte.
+    """
+    payload = bytearray()
+    payload.append(mode_idx)
+    payload.append(prompt_b1)
+    payload.append(prompt_b2)
+    payload.extend(encode_mode_name(name))
+    payload.append(cnc_level)
+    payload.append(1 if auto_cnc else 0)
+    payload.append(spatial)
+    payload.append(1 if wind_block else 0)
+    return bytes(payload)

--- a/python/pybmap/devices/qc45.py
+++ b/python/pybmap/devices/qc45.py
@@ -1,0 +1,120 @@
+"""Bose QC45 device configuration.
+
+Codename "duran", product ID 0x4039, firmware 4.0.4.
+RFCOMM channel 8, requires INIT_PACKET (0,1) before responding.
+
+Capabilities verified against real hardware:
+  - Battery, firmware, serial, product name: GET works
+  - Device name, sidetone, voice prompts: GET + SETGET works
+  - Buttons: GET + SETGET works (Shortcut button with SwitchDevice action)
+  - CNC noise cancellation [1.5]: GET-only, SETGET requires auth
+  - CNC via AudioModes [31.6]: SETGET works on editable modes (39-byte payload)
+      Editable modes 2-3 accept cnc_level 0-10 via ModeConfig SETGET
+  - Mode switching [31.3]: START works (silent or with voice prompt)
+  - EQ [1.7]: GET + SETGET works (3-band: Bass/Mid/Treble, range -10 to +10)
+  - Multipoint [1.10]: GET works
+  - Power state [7.4]: GET works
+  - Pairing mode: START works
+  - No ANR [1.6], no auto-pause [1.24], no auto-answer [1.27]
+  - No AudioSettings [31.10] (FuncNotSupp — use ModeConfig [31.6] instead)
+"""
+
+from . import parsers
+
+RFCOMM_CHANNEL = 8
+
+INIT_PACKET = (0, 1)
+
+DEVICE_INFO = {
+    "name": "Bose QuietComfort 45",
+    "codename": "duran",
+    "platform": "CSR8670",
+    "product_id": 0x4039,
+    "variant": 0x01,
+}
+
+FEATURES = {
+    "battery": {
+        "addr": (2, 2),
+        "parser": parsers.parse_battery,
+    },
+    "firmware": {
+        "addr": (0, 5),
+        "parser": parsers.parse_firmware,
+    },
+    "product_name": {
+        "addr": (1, 2),
+        "parser": parsers.parse_product_name,
+        "builder": lambda name: name.encode("utf-8"),
+    },
+    "voice_prompts": {
+        "addr": (1, 3),
+        "parser": parsers.parse_voice_prompts,
+        "builder": parsers.build_voice_prompts,
+    },
+    "cnc": {
+        "addr": (1, 5),
+        "parser": parsers.parse_cnc,
+    },
+    "eq": {
+        "addr": (1, 7),
+        "parser": parsers.parse_eq,
+        "builder": parsers.build_eq_band,
+    },
+    "buttons": {
+        "addr": (1, 9),
+        "parser": parsers.parse_buttons,
+        "builder": parsers.build_buttons,
+    },
+    "multipoint": {
+        "addr": (1, 10),
+        "parser": parsers.parse_multipoint,
+        "builder": parsers.build_toggle,
+    },
+    "sidetone": {
+        "addr": (1, 11),
+        "parser": parsers.parse_sidetone,
+        "builder": parsers.build_sidetone,
+    },
+    "pairing": {
+        "addr": (4, 8),
+    },
+    # AudioModes block (31) — 39-byte SETGET, 47-byte STATUS
+    "get_all_modes": {
+        "addr": (31, 1),
+    },
+    "current_mode": {
+        "addr": (31, 3),
+    },
+    "default_mode": {
+        "addr": (31, 4),
+    },
+    "mode_config": {
+        "addr": (31, 6),
+        "parser": parsers.parse_mode_config_47,
+        "builder": parsers.build_mode_config_39,
+    },
+    "favorites": {
+        "addr": (31, 8),
+    },
+}
+
+PRESET_MODES = {
+    "quiet": {"idx": 0, "description": "Quiet — full ANC (cnc=0)"},
+    "aware": {"idx": 1, "description": "Aware — transparency (cnc=10)"},
+}
+
+MODE_BY_IDX = {m["idx"]: name for name, m in PRESET_MODES.items()}
+
+EDITABLE_SLOTS = [2, 3]
+
+STATUS_OFFSETS = {
+    "prompt_b1": 1,
+    "prompt_b2": 2,
+    "editable": 3,
+    "configured": 4,
+    "cnc_level": 42,
+    "auto_cnc": 43,
+    "spatial": 44,
+    "wind_block": 45,
+}

--- a/python/tests/test_qc45.py
+++ b/python/tests/test_qc45.py
@@ -1,0 +1,186 @@
+"""Tests for QC45 device configuration."""
+
+from pybmap.devices import qc45, parsers, DEVICES
+
+
+class TestQC45Config:
+    def test_qc45_registered(self):
+        assert "qc45" in DEVICES
+
+    def test_has_device_info(self):
+        assert qc45.DEVICE_INFO["product_id"] == 0x4039
+        assert qc45.DEVICE_INFO["codename"] == "duran"
+
+    def test_has_core_features(self):
+        for feat in ["battery", "firmware", "product_name", "voice_prompts",
+                      "cnc", "eq", "buttons", "multipoint", "sidetone", "pairing"]:
+            assert feat in qc45.FEATURES, "Missing feature: %s" % feat
+
+    def test_has_audio_modes(self):
+        assert "get_all_modes" in qc45.FEATURES
+        assert "current_mode" in qc45.FEATURES
+        assert "mode_config" in qc45.FEATURES
+
+    def test_no_audio_settings(self):
+        assert "audio_settings" not in qc45.FEATURES
+
+    def test_no_auto_pause(self):
+        assert "auto_pause" not in qc45.FEATURES
+
+    def test_rfcomm_channel_8(self):
+        assert qc45.RFCOMM_CHANNEL == 8
+
+    def test_has_init_packet(self):
+        assert qc45.INIT_PACKET == (0, 1)
+
+    def test_eq_has_builder(self):
+        assert qc45.FEATURES["eq"].get("builder") is not None
+
+    def test_preset_modes(self):
+        assert "quiet" in qc45.PRESET_MODES
+        assert "aware" in qc45.PRESET_MODES
+        assert qc45.PRESET_MODES["quiet"]["idx"] == 0
+        assert qc45.PRESET_MODES["aware"]["idx"] == 1
+
+    def test_editable_slots(self):
+        assert 2 in qc45.EDITABLE_SLOTS
+        assert 3 in qc45.EDITABLE_SLOTS
+        assert 0 not in qc45.EDITABLE_SLOTS
+        assert 1 not in qc45.EDITABLE_SLOTS
+
+    def test_mode_config_has_parser_and_builder(self):
+        mc = qc45.FEATURES["mode_config"]
+        assert mc["parser"] is not None
+        assert mc["builder"] is not None
+
+    def test_mode_config_uses_39byte_format(self):
+        assert qc45.FEATURES["mode_config"]["builder"] is parsers.build_mode_config_39
+        assert qc45.FEATURES["mode_config"]["parser"] is parsers.parse_mode_config_47
+
+
+class TestQC45ModeConfigParser:
+    """Test the 47-byte ModeConfig STATUS parser used by QC45."""
+
+    def _quiet_payload(self):
+        return bytes.fromhex(
+            "0000010000015175696574"
+            "000000000000000000000000000000000000000000"
+            "000000000000000000000000000000"
+        )
+
+    def _music_payload(self):
+        return bytes.fromhex(
+            "02000c0101014d75736963"
+            "000000000000000000000000000000000000000000"
+            "000000000000000000090500000000"
+        )
+
+    def test_parse_quiet_mode(self):
+        # Exact payload from probe: mode 0, Quiet, cnc=0, preset
+        payload = bytes.fromhex(
+            "0000010000015175696574"
+            "000000000000000000000000000000000000000000"
+            "000000000000000000000000000000"
+        )
+        config = parsers.parse_mode_config_47(payload)
+        assert config is not None
+        assert config.mode_idx == 0
+        assert config.name == "Quiet"
+        assert config.editable is False
+        assert config.cnc_level == 0
+
+    def test_parse_aware_mode(self):
+        # Exact payload from probe: mode 1, Aware, cnc=10, preset
+        payload = bytes.fromhex(
+            "0100020000014177617265"
+            "000000000000000000000000000000000000000000"
+            "000000000000000000000a00000000"
+        )
+        config = parsers.parse_mode_config_47(payload)
+        assert config is not None
+        assert config.mode_idx == 1
+        assert config.name == "Aware"
+        assert config.editable is False
+        assert config.cnc_level == 10
+
+    def test_parse_editable_music_mode(self):
+        # Exact payload from probe after SETGET: mode 2, Music, cnc=3, editable
+        payload = bytes.fromhex(
+            "02000c0101014d75736963"
+            "000000000000000000000000000000000000000000"
+            "000000000000000000090300000000"
+        )
+        config = parsers.parse_mode_config_47(payload)
+        assert config is not None
+        assert config.mode_idx == 2
+        assert config.name == "Music"
+        assert config.editable is True
+        assert config.configured is True
+        assert config.cnc_level == 3
+
+    def test_parse_setget_echo_39bytes(self):
+        payload = parsers.build_mode_config_39(
+            2, "Music", cnc_level=7, prompt_b1=0, prompt_b2=12,
+        )
+        assert len(payload) == 39
+        config = parsers.parse_mode_config_47(payload)
+        assert config is not None
+        assert config.mode_idx == 2
+        assert config.name == "Music"
+        assert config.cnc_level == 7
+
+    def test_anc_toggle_always_false(self):
+        # QC45 has no ancToggle field (47 bytes vs 48)
+        payload = bytes.fromhex(
+            "0000010000015175696574"
+            "000000000000000000000000000000000000000000"
+            "000000000000000000000000000000"
+        )
+        config = parsers.parse_mode_config_47(payload)
+        assert config.anc_toggle is False
+
+
+class TestQC45ModeConfigBuilder:
+    """Test the 39-byte ModeConfig SETGET builder used by QC45."""
+
+    def test_build_39_bytes(self):
+        payload = parsers.build_mode_config_39(2, "Music", cnc_level=5)
+        assert len(payload) == 39
+
+    def test_build_mode_index(self):
+        payload = parsers.build_mode_config_39(3, "Test", cnc_level=7)
+        assert payload[0] == 3
+
+    def test_build_prompt_bytes(self):
+        payload = parsers.build_mode_config_39(
+            2, "Music", prompt_b1=0, prompt_b2=12,
+        )
+        assert payload[1] == 0
+        assert payload[2] == 12
+
+    def test_build_name_encoding(self):
+        payload = parsers.build_mode_config_39(2, "Music")
+        name = payload[3:35].split(b"\x00", 1)[0]
+        assert name == b"Music"
+
+    def test_build_cnc_level(self):
+        payload = parsers.build_mode_config_39(2, "Test", cnc_level=7)
+        assert payload[35] == 7
+
+    def test_build_trailing_fields(self):
+        payload = parsers.build_mode_config_39(
+            2, "Test", cnc_level=5, auto_cnc=False,
+            spatial=0, wind_block=False,
+        )
+        assert payload[36] == 0  # auto_cnc
+        assert payload[37] == 0  # spatial
+        assert payload[38] == 0  # wind_block
+
+    def test_roundtrip(self):
+        payload = parsers.build_mode_config_39(
+            2, "Custom", cnc_level=3, prompt_b1=0, prompt_b2=12,
+        )
+        config = parsers.parse_mode_config_47(payload)
+        assert config.mode_idx == 2
+        assert config.name == "Custom"
+        assert config.cnc_level == 3


### PR DESCRIPTION
## Summary
- Add QC45 device configuration (`devices/qc45.py`) with mode_config-based feature set for CSR8670 firmware
- Add `parse_mode_config_47` and `build_mode_config_39` parsers for the QC45's 39/47-byte ModeConfig format (no ancToggle byte)
- Extend `set_cnc()` in `connection.py` to use mode_config path when audio_settings is unavailable
- Register QC45 in catalog, device registry, and product ID lookup
- Add QC45 test suite (186 tests)

## Test plan
- [x] `python/.venv/bin/pytest python/tests/test_qc45.py -v` — all QC45 tests pass
- [x] `python/.venv/bin/pytest python/tests/test_qc_ultra2.py -v` — no regressions
- [ ] Integration test with physical QC45 device (requires `BMAP_INTEGRATION=1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)