### PR TITLE
Add QuietComfort Headphones (prince) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Release](https://img.shields.io/github/v/release/aaronsb/bosectl)](https://github.com/aaronsb/bosectl/releases/latest)
-[![Devices](https://img.shields.io/badge/Devices-2_supported_·_14_known-green)](docs/architecture.md#device-catalog)
+[![Devices](https://img.shields.io/badge/Devices-3_supported_·_38_known-green)](docs/architecture.md#device-catalog)
 [![Python 3](https://img.shields.io/badge/Python-3-3572A5.svg)](python/)
 [![Rust](https://img.shields.io/badge/Rust-1.70+-DEA584.svg)](rust/)
 [![C++17](https://img.shields.io/badge/C++-17-f34b7d.svg)](cpp/)
@@ -26,6 +26,7 @@ connection to the headphones.
 | Device | NC Control | EQ | Spatial | Profiles | Buttons | Status |
 |--------|-----------|-----|---------|----------|---------|--------|
 | **QC Ultra Headphones 2** | CNC 0-10 slider | 3-band | room/head | 7 custom slots | Shortcut remap | Verified |
+| **QuietComfort Headphones** | CNC 0-10 + Wind Block via ModeConfig | — | field observed | 2 user slots observed | — | Verified (`prince`) |
 | **QuietComfort 35 / 35 II** | ANR off/high/wind/low | — | — | — | Action remap (VPA/ANC) | Verified |
 
 ### Device Roadmap
@@ -38,7 +39,6 @@ product ID but don't have tested configurations yet — contributions welcome:
 |--------|----------|----------|-----|
 | Noise Cancelling Headphones 700 | goodyear | Headphones | `0x4024` |
 | QuietComfort 45 | duran | Headphones | `0x4039` |
-| QuietComfort Headphones | prince | Headphones | `0x4075` |
 | QuietComfort Ultra Headphones | lonestarr | Headphones | `0x4066` |
 | QuietComfort Earbuds II | smalls | Earbuds | `0x4064` |
 | QuietComfort Ultra Earbuds | scotty | Earbuds | `0x4072` |
@@ -46,7 +46,8 @@ product ID but don't have tested configurations yet — contributions welcome:
 | SoundLink Flex | phelps | Speaker | `0xBC59` |
 | SoundLink Flex 2 | mathers | Speaker | `0xBC61` |
 
-Adding a new device is a configuration entry — no library code changes needed.
+Adding a new device is usually a configuration entry; devices with different
+payload layouts may need a parser/builder pair.
 See [Adding a New Device](docs/architecture.md#adding-a-new-device).
 
 ## Quick Start
@@ -60,7 +61,7 @@ with pybmap.connect() as dev:
     print(dev.battery())            # 80
     print(dev.name())               # "Obsidian Countess"
     dev.set_anr("high")             # QC35: full noise cancellation
-    dev.set_cnc(8)                  # QC Ultra 2: CNC level 0-10
+    dev.set_cnc(8)                  # CNC level 0-10 (0=max ANC)
     dev.set_eq(3, 0, -2)            # Bass +3, mid flat, treble -2
     dev.set_buttons(0x10, 4, 2)     # Remap Action button to ANC
 ```
@@ -71,7 +72,7 @@ use bmap::connect;
 let dev = connect(None, None)?;
 println!("{}%", dev.battery()?);    // 80
 dev.set_anr("high")?;              // QC35
-dev.set_cnc(8)?;                   // QC Ultra 2
+dev.set_cnc(8)?;                   // CNC level 0-10 (0=max ANC)
 ```
 
 ```cpp
@@ -80,7 +81,7 @@ dev.set_cnc(8)?;                   // QC Ultra 2
 auto dev = bmap::connect();
 std::cout << (int)dev->battery() << "%\n";
 dev->set_anr("high");              // QC35
-dev->set_cnc(8);                   // QC Ultra 2
+dev->set_cnc(8);                   // CNC level 0-10 (0=max ANC)
 ```
 
 ### CLI Usage
@@ -88,7 +89,7 @@ dev->set_cnc(8);                   // QC Ultra 2
 ```bash
 # Auto-detects paired Bose device
 bosectl status              # Show model, battery, mode, settings
-bosectl cnc 7               # Noise cancellation level (QC Ultra 2)
+bosectl cnc 7               # Noise cancellation level (0=max ANC)
 bosectl anr high            # Noise cancellation mode (QC35)
 bosectl eq 3 0 -2           # EQ: bass/mid/treble
 bosectl buttons set ANC     # Remap programmable button
@@ -111,8 +112,9 @@ pybmap.modalias(0x4082)   # "bluetooth:v05A7p4082d0000"
 
 # Check support status
 pybmap.is_supported(0x4082)  # True — has tested config
+pybmap.is_supported(0x4075)  # True — QuietComfort Headphones (prince)
 pybmap.is_supported(0x4039)  # False — QC45, recognized but untested
-pybmap.supported_devices()   # [wolfcastle, baywolf, edith, wolverine]
+pybmap.supported_devices()   # [wolfcastle, baywolf, edith, prince, wolverine]
 pybmap.known_devices()       # full catalog
 ```
 
@@ -177,8 +179,8 @@ Application → BmapConnection → Device Config → Transport → Protocol → 
 - **Catalog** — all known Bose BMAP devices with product IDs, codenames, and USB identifiers
 
 Device differences (RFCOMM channel, init packets, feature availability) are
-expressed as config data, not code branches. Adding a new device is a
-config entry pointing to existing parsers.
+expressed as config data. Devices with new payload layouts can point to
+device-specific parsers and builders.
 
 Full documentation: **[docs/architecture.md](docs/architecture.md)**
 
@@ -193,7 +195,8 @@ ECDH authentication, **SETGET** (operator 2) and **START** (operator 5)
 are unauthenticated on the Settings and AudioModes blocks. This gives
 full control over every user-facing setting.
 
-Full protocol reference: **[NOTES.md](NOTES.md)**
+Full protocol reference: **[NOTES.md](NOTES.md)** and
+**[QuietComfort Headphones notes](docs/quietcomfort-headphones-prince.md)**.
 
 ### How We Found This
 

--- a/cpp/src/catalog.h
+++ b/cpp/src/catalog.h
@@ -39,7 +39,7 @@ inline const std::vector<BoseDevice>& catalog() {
         {0x402B, "beanie",     "Hearphones II",                           Category::Headphones, nullptr},
         {0x4039, "duran",      "QuietComfort 45",                         Category::Headphones, nullptr},
         {0x4066, "lonestarr",  "QuietComfort Ultra Headphones",           Category::Headphones, nullptr},
-        {0x4075, "prince",     "QuietComfort Headphones",                 Category::Headphones, nullptr},
+        {0x4075, "prince",     "QuietComfort Headphones",                 Category::Headphones, "qc_prince"},
         {0x4082, "wolverine",  "QuietComfort Ultra Headphones (2nd Gen)", Category::Headphones, "qc_ultra2"},
         // Earbuds
         {0x4012, "ice",        "SoundSport",                              Category::Earbuds, nullptr},

--- a/cpp/src/connection.h
+++ b/cpp/src/connection.h
@@ -147,11 +147,16 @@ public:
 
     // Returns (cnc, auto_cnc, spatial, wind, anc)
     std::array<uint8_t, 5> audio_settings() {
-        auto addr = require(config_.audio_settings, "audio_settings");
-        auto p = get(addr);
-        std::array<uint8_t, 5> out = {0, 0, 0, 1, 1};
-        for (size_t i = 0; i < 5 && i < p.size(); i++) out[i] = p[i];
-        return out;
+        if (config_.audio_settings) {
+            auto p = get(*config_.audio_settings);
+            std::array<uint8_t, 5> out = {0, 0, 0, 1, 1};
+            for (size_t i = 0; i < 5 && i < p.size(); i++) out[i] = p[i];
+            return out;
+        }
+        auto mc = current_mode_config();
+        return {mc.cnc_level, 0, mc.spatial,
+                static_cast<uint8_t>(mc.wind_block ? 1 : 0),
+                static_cast<uint8_t>(mc.anc_toggle ? 1 : 0)};
     }
 
     void set_eq(int8_t bass, int8_t mid, int8_t treble) {
@@ -331,15 +336,18 @@ private:
     // Write audio settings via [31.10] preserving non-overridden fields.
     // Use 255 as "don't change" for any parameter.
     void update_audio_settings(uint8_t cnc, uint8_t spatial, uint8_t wind, uint8_t anc) {
-        auto addr = require(config_.audio_settings, "audio_settings");
-        auto cur = get(addr);
-        std::vector<uint8_t> p = {0, 0, 0, 1, 1};
-        for (size_t i = 0; i < 5 && i < cur.size(); i++) p[i] = cur[i];
-        if (cnc != 255) p[0] = cnc;
-        if (spatial != 255) p[2] = spatial;
-        if (wind != 255) p[3] = wind;
-        if (anc != 255) p[4] = anc;
-        setget(addr, p);
+        if (config_.audio_settings) {
+            auto cur = get(*config_.audio_settings);
+            std::vector<uint8_t> p = {0, 0, 0, 1, 1};
+            for (size_t i = 0; i < 5 && i < cur.size(); i++) p[i] = cur[i];
+            if (cnc != 255) p[0] = cnc;
+            if (spatial != 255) p[2] = spatial;
+            if (wind != 255) p[3] = wind;
+            if (anc != 255) p[4] = anc;
+            setget(*config_.audio_settings, p);
+            return;
+        }
+        update_current_mode_config(cnc, spatial, wind, anc);
     }
 
     std::pair<uint8_t, ModeConfig> ensure_editable_profile() {
@@ -380,9 +388,36 @@ private:
         throw std::runtime_error("No free profile slot available");
     }
 
+    ModeConfig current_mode_config() {
+        auto idx = mode_idx();
+        auto all = modes();
+        for (auto& m : all) {
+            if (m.mode_idx == idx) return m;
+        }
+        throw std::runtime_error("Current mode config not available");
+    }
+
+    void update_current_mode_config(uint8_t cnc, uint8_t spatial, uint8_t wind, uint8_t anc) {
+        if (anc != 255 && !config_.supports_anc_toggle) {
+            throw std::runtime_error("ANC on/off toggle not supported on this device");
+        }
+        auto mc = current_mode_config();
+        if (!mc.editable) {
+            throw std::runtime_error("Current mode is not editable on this device: " + mc.name);
+        }
+        if (cnc != 255) mc.cnc_level = cnc;
+        if (spatial != 255) mc.spatial = spatial;
+        if (wind != 255) mc.wind_block = wind != 0;
+        if (anc != 255) mc.anc_toggle = anc != 0;
+        write_mode(mc.mode_idx, mc);
+    }
+
     void write_mode(uint8_t slot, const ModeConfig& mc) {
         auto addr = require(config_.mode_config, "mode_config");
-        auto payload = build_mode_config_40(
+        if (!config_.build_mode_config) {
+            throw std::runtime_error("Mode config builder not supported on this device");
+        }
+        auto payload = config_.build_mode_config(
             slot, mc.name, mc.cnc_level, mc.spatial,
             mc.wind_block, mc.anc_toggle, mc.prompt_b1, mc.prompt_b2);
         auto pkt = bmap_packet(addr.fblock, addr.func, Operator::SetGet, payload);

--- a/cpp/src/device.h
+++ b/cpp/src/device.h
@@ -1,6 +1,7 @@
 // Device configuration and parser types.
 #pragma once
 
+#include <algorithm>
 #include <array>
 #include <cstdint>
 #include <functional>
@@ -80,6 +81,8 @@ struct DeviceStatus {
 };
 
 using ModeConfigParser = std::function<std::optional<ModeConfig>(const std::vector<uint8_t>&)>;
+using ModeConfigBuilder = std::function<std::vector<uint8_t>(
+    uint8_t, const std::string&, uint8_t, uint8_t, bool, bool, uint8_t, uint8_t)>;
 
 struct DeviceConfig {
     DeviceInfo info;
@@ -112,6 +115,8 @@ struct DeviceConfig {
     std::vector<std::pair<std::string, PresetMode>> preset_modes;
     std::vector<uint8_t> editable_slots;
     ModeConfigParser parse_mode_config;
+    ModeConfigBuilder build_mode_config;
+    bool supports_anc_toggle = false;
 };
 
 // ── Shared Parsers ──────────────────────────────────────────────────────────
@@ -331,6 +336,41 @@ inline std::optional<ModeConfig> parse_mode_config_qc_ultra2(const std::vector<u
     return std::nullopt;
 }
 
+// ── QuietComfort Headphones / prince Mode Config Parser ────────────────────
+
+inline std::optional<ModeConfig> parse_mode_config_prince(const std::vector<uint8_t>& p) {
+    if (p.size() < 6) return std::nullopt;
+
+    ModeConfig mc;
+    mc.mode_idx = p[0];
+    mc.prompt_b1 = p[1];
+    mc.prompt_b2 = p[2];
+    mc.anc_toggle = false;
+
+    if (p.size() >= 47) {
+        mc.editable = p[3] != 0;
+        mc.configured = p[4] != 0;
+        auto name_end = std::find(p.data() + 6, p.data() + 38, '\0');
+        mc.name = std::string(reinterpret_cast<const char*>(p.data() + 6),
+                              reinterpret_cast<const char*>(name_end));
+        mc.cnc_level = p[42];
+        mc.spatial = p[44];
+        mc.wind_block = p[46] != 0;
+        return mc;
+    } else if (p.size() >= 39) {
+        mc.editable = true;
+        mc.configured = true;
+        auto name_end = std::find(p.data() + 3, p.data() + 35, '\0');
+        mc.name = std::string(reinterpret_cast<const char*>(p.data() + 3),
+                              reinterpret_cast<const char*>(name_end));
+        mc.cnc_level = p[35];
+        mc.spatial = p[37];
+        mc.wind_block = p[38] != 0;
+        return mc;
+    }
+    return std::nullopt;
+}
+
 // ── Mode Config Builder ─────────────────────────────────────────────────────
 
 inline std::vector<uint8_t> build_mode_config_40(
@@ -349,6 +389,24 @@ inline std::vector<uint8_t> build_mode_config_40(
     payload.push_back(spatial);
     payload.push_back(wind_block ? 1 : 0);
     payload.push_back(anc_toggle ? 1 : 0);
+    return payload;
+}
+
+inline std::vector<uint8_t> build_mode_config_39(
+    uint8_t mode_idx, const std::string& name, uint8_t cnc_level, uint8_t spatial,
+    bool wind_block, bool /*anc_toggle*/, uint8_t prompt_b1 = 0, uint8_t prompt_b2 = 0)
+{
+    std::vector<uint8_t> payload;
+    payload.reserve(39);
+    payload.push_back(mode_idx);
+    payload.push_back(prompt_b1);
+    payload.push_back(prompt_b2);
+    auto encoded = encode_mode_name(name);
+    payload.insert(payload.end(), encoded.begin(), encoded.end());
+    payload.push_back(cnc_level);
+    payload.push_back(0); // auto_cnc
+    payload.push_back(spatial);
+    payload.push_back(wind_block ? 1 : 0);
     return payload;
 }
 

--- a/cpp/src/devices.h
+++ b/cpp/src/devices.h
@@ -36,6 +36,34 @@ inline DeviceConfig qc_ultra2() {
     };
     c.editable_slots = {4, 5, 6, 7, 8, 9, 10};
     c.parse_mode_config = parse_mode_config_qc_ultra2;
+    c.build_mode_config = build_mode_config_40;
+    c.supports_anc_toggle = true;
+    return c;
+}
+
+/// Bose QuietComfort Headphones -- prince, product ID 0x4075.
+/// Verified against firmware 1.0.6-80+f5f219b. RFCOMM channel 8.
+inline DeviceConfig qc_prince() {
+    DeviceConfig c;
+    c.info = {"Bose QuietComfort Headphones", "prince", "Unknown"};
+    c.rfcomm_channel = 8;
+    c.battery = Addr{2, 2};
+    c.firmware = Addr{0, 5};
+    c.product_name = Addr{1, 2};
+    c.voice_prompts = Addr{1, 3};
+    c.cnc = Addr{1, 5};
+    c.pairing = Addr{4, 8};
+    c.get_all_modes = Addr{31, 1};
+    c.current_mode = Addr{31, 3};
+    c.mode_config = Addr{31, 6};
+    c.preset_modes = {
+        {"quiet", {0, "Quiet - full ANC"}},
+        {"aware", {1, "Aware - transparency"}},
+    };
+    c.editable_slots = {2, 3};
+    c.parse_mode_config = parse_mode_config_prince;
+    c.build_mode_config = build_mode_config_39;
+    c.supports_anc_toggle = false;
     return c;
 }
 
@@ -68,6 +96,7 @@ inline DeviceConfig qc35() {
 inline std::optional<DeviceConfig> get_device(const std::string& name) {
     if (name == "qc_ultra2") return qc_ultra2();
     if (name == "qc35") return qc35();
+    if (name == "qc_prince") return qc_prince();
     return std::nullopt;
 }
 

--- a/cpp/src/main.cpp
+++ b/cpp/src/main.cpp
@@ -30,7 +30,7 @@ static void usage() {
               << "  off                 Power off\n\n"
               << "Environment:\n"
               << "  BMAP_MAC=XX:XX:XX:XX:XX:XX   Device MAC\n"
-              << "  BMAP_DEVICE=qc_ultra2         Device type\n";
+              << "  BMAP_DEVICE=qc_ultra2|qc_prince|qc35   Device type\n";
 }
 
 static bool is_on(const std::string& s) {
@@ -118,8 +118,12 @@ int main(int argc, char** argv) {
                 std::string v = argv[2];
                 dev.set_anc(v == "on" || v == "1" || v == "true");
             }
-            auto s = dev.audio_settings();
-            std::cout << (s[4] ? "on" : "off") << "\n";
+            if (!dev.config().audio_settings && !dev.config().supports_anc_toggle) {
+                std::cout << "unsupported\n";
+            } else {
+                auto s = dev.audio_settings();
+                std::cout << (s[4] ? "on" : "off") << "\n";
+            }
         } else if (cmd == "wind") {
             if (argc > 2) {
                 std::string v = argv[2];

--- a/cpp/tests/test_catalog.cpp
+++ b/cpp/tests/test_catalog.cpp
@@ -35,12 +35,21 @@ TEST(catalog_lookup_qc_ultra2_earbuds) {
     ASSERT_EQ(std::string(dev->config), std::string("qc_ultra2"));
 }
 
+TEST(catalog_lookup_qc_prince) {
+    auto* dev = lookup_device(0x4075);
+    ASSERT_TRUE(dev != nullptr);
+    ASSERT_EQ(std::string(dev->codename), std::string("prince"));
+    ASSERT_TRUE(dev->config != nullptr);
+    ASSERT_EQ(std::string(dev->config), std::string("qc_prince"));
+}
+
 TEST(catalog_lookup_unknown) {
     ASSERT_TRUE(lookup_device(0xFFFF) == nullptr);
 }
 
 TEST(catalog_is_supported) {
     ASSERT_TRUE(is_supported(0x4082));
+    ASSERT_TRUE(is_supported(0x4075));
     ASSERT_TRUE(is_supported(0x4020));
     ASSERT_FALSE(is_supported(0x4024));  // NCH 700, no config
     ASSERT_FALSE(is_supported(0xFFFF));
@@ -48,7 +57,7 @@ TEST(catalog_is_supported) {
 
 TEST(catalog_supported_devices) {
     auto devs = supported_devices();
-    ASSERT_TRUE(devs.size() >= 4u);  // wolfcastle, baywolf, edith, wolverine
+    ASSERT_TRUE(devs.size() >= 5u);  // wolfcastle, baywolf, edith, prince, wolverine
     for (auto* d : devs) {
         ASSERT_TRUE(d->config != nullptr);
     }

--- a/cpp/tests/test_connection.cpp
+++ b/cpp/tests/test_connection.cpp
@@ -13,6 +13,7 @@ using namespace bmap;
 class MockTransport : public Transport {
 public:
     std::map<std::pair<uint8_t,uint8_t>, std::vector<uint8_t>> responses;
+    std::vector<std::vector<uint8_t>> sent;
 
     void add(uint8_t fblock, uint8_t func, uint8_t op, std::vector<uint8_t> payload) {
         std::vector<uint8_t> resp = {fblock, func, op, static_cast<uint8_t>(payload.size())};
@@ -21,6 +22,7 @@ public:
     }
 
     std::vector<uint8_t> send_recv(const std::vector<uint8_t>& packet) override {
+        sent.push_back(packet);
         auto key = std::make_pair(packet[0], packet[1]);
         auto it = responses.find(key);
         if (it != responses.end()) return it->second;
@@ -117,6 +119,44 @@ TEST(error_response_throws) {
     try { dev.cnc(); } catch (const std::runtime_error& e) {
         threw = true;
         ASSERT_TRUE(std::string(e.what()).find("auth") != std::string::npos);
+    }
+    ASSERT_TRUE(threw);
+}
+
+TEST(prince_set_wind_uses_mode_config_fallback) {
+    std::vector<uint8_t> music = {
+        0x03,0x00,0x0c,0x01,0x01,0x00,0x4d,0x75,0x73,0x69,0x63,0x00,0x00,0x00,0x00,0x00,
+        0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+        0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x09,0x05,0x00,0x00,0x00,0x00,
+    };
+    auto raw = new MockTransport();
+    raw->add(31, 3, 0x03, {3});
+    std::vector<uint8_t> get_all = {31, 6, 0x03, static_cast<uint8_t>(music.size())};
+    get_all.insert(get_all.end(), music.begin(), music.end());
+    raw->responses[{31, 1}] = get_all;
+    raw->add(31, 6, 0x03, music);
+    MockTransport* view = raw;
+    BmapConnection dev(std::unique_ptr<Transport>(raw), qc_prince());
+
+    dev.set_wind(true);
+
+    auto last = view->sent.back();
+    ASSERT_EQ(last[0], 31);
+    ASSERT_EQ(last[1], 6);
+    ASSERT_EQ(last[2], 0x02);
+    ASSERT_EQ(last[3], 39);
+    ASSERT_EQ(last[4], 3);
+    ASSERT_EQ(last[4 + 35], 5);
+    ASSERT_EQ(last[4 + 38], 1);
+}
+
+TEST(prince_set_anc_rejects_missing_toggle) {
+    auto t = std::make_unique<MockTransport>();
+    BmapConnection dev(std::move(t), qc_prince());
+    bool threw = false;
+    try { dev.set_anc(false); } catch (const std::runtime_error& e) {
+        threw = true;
+        ASSERT_TRUE(std::string(e.what()).find("ANC") != std::string::npos);
     }
     ASSERT_TRUE(threw);
 }

--- a/cpp/tests/test_parsers.cpp
+++ b/cpp/tests/test_parsers.cpp
@@ -66,6 +66,17 @@ TEST(build_mode_config_40_length) {
     ASSERT_EQ(p[39], 1);   // anc
 }
 
+TEST(build_mode_config_39_length) {
+    auto p = build_mode_config_39(3, "Music", 5, 0, true, false, 0, 12);
+    ASSERT_EQ(p.size(), 39u);
+    ASSERT_EQ(p[0], 3);
+    ASSERT_EQ(p[1], 0);
+    ASSERT_EQ(p[2], 12);
+    ASSERT_EQ(std::string(p.begin() + 3, p.begin() + 8), "Music");
+    ASSERT_EQ(p[35], 5);
+    ASSERT_EQ(p[38], 1);
+}
+
 TEST(parse_voice_prompts_disabled) {
     auto [on, lang] = parse_voice_prompts({0x01});
     ASSERT_FALSE(on);
@@ -94,4 +105,20 @@ TEST(mode_config_roundtrip_40) {
 TEST(mode_config_too_short) {
     auto mc = parse_mode_config_qc_ultra2({0, 0, 0});
     ASSERT_FALSE(mc.has_value());
+}
+
+TEST(mode_config_prince_capture) {
+    std::vector<uint8_t> payload = {
+        0x03,0x00,0x0c,0x01,0x01,0x00,0x4d,0x75,0x73,0x69,0x63,0x00,0x00,0x00,0x00,0x00,
+        0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+        0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x09,0x05,0x00,0x00,0x00,0x00,
+    };
+    auto mc = parse_mode_config_prince(payload);
+    ASSERT_TRUE(mc.has_value());
+    ASSERT_EQ(mc->mode_idx, 3);
+    ASSERT_EQ(mc->prompt_b2, 12);
+    ASSERT_EQ(mc->name, "Music");
+    ASSERT_EQ(mc->cnc_level, 5);
+    ASSERT_FALSE(mc->wind_block);
+    ASSERT_FALSE(mc->anc_toggle);
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -132,17 +132,17 @@ Each feature entry maps a name to its protocol address and codec functions:
 
 **Device quirks are expressed as config differences, not code branches:**
 
-| Property | QC Ultra 2 | QC35 |
-|----------|-----------|------|
-| RFCOMM channel | 2 | 8 |
-| Init packet | None | GET [0.1] required |
-| Noise control | CNC [1.5] (0-10 slider) | ANR [1.6] (off/high/wind/low) |
-| EQ | 3-band [1.7] | Not supported |
-| Spatial audio | [31.6] ModeConfig | Not supported |
-| Mode profiles | 7 editable slots (4-10) | None |
-| Sidetone | [1.11] | [1.11] |
-| Multipoint | [1.10] | Not supported |
-| Button remap | Shortcut (0x80) | Action (0x10) |
+| Property | QC Ultra 2 | QuietComfort Headphones (`prince`) | QC35 |
+|----------|-----------|-------------------------------------|------|
+| RFCOMM channel | 2 | 8 | 8 |
+| Init packet | None | None | GET [0.1] required |
+| Noise control | CNC [1.5] / live [31.10] | CNC/wind via [31.6] ModeConfig | ANR [1.6] (off/high/wind/low) |
+| EQ | 3-band [1.7] | Not verified | Not supported |
+| Spatial audio | [31.6] ModeConfig | Field observed in [31.6] | Not supported |
+| Mode profiles | 7 editable slots (4-10) | 2 editable slots observed (2-3) | None |
+| Sidetone | [1.11] | Not verified | [1.11] |
+| Multipoint | [1.10] | Not verified | Not supported |
+| Button remap | Shortcut (0x80) | Not verified | Action (0x10) |
 
 ### BmapConnection
 
@@ -206,6 +206,7 @@ build_anr("high")                         →  bytes([0x01])
 build_sidetone(2)                         →  bytes([0x01, 0x02])
 build_buttons(0x10, 4, 2)                 →  bytes([0x10, 0x04, 0x02])
 build_mode_config_40(5, "Custom", cnc_level=8)  →  40-byte payload
+build_mode_config_39(3, "Music", cnc_level=5)   →  39-byte payload
 ```
 
 Builders accept both integer IDs and string names where applicable
@@ -301,10 +302,10 @@ Bose's firmware manifest at `downloads.bose.com/lookup.xml`.
 
 ```mermaid
 graph TD
-    CAT[Device Catalog<br/>14 known BMAP devices] --> SUP[Supported<br/>config ≠ None]
+    CAT[Device Catalog<br/>known BMAP devices] --> SUP[Supported<br/>config ≠ None]
     CAT --> UNSUP[Recognized but Unsupported<br/>config = None]
     SUP --> DISC[Discovery<br/>PID → config lookup]
-    SUP --> CFG[Device Configs<br/>qc_ultra2, qc35]
+    SUP --> CFG[Device Configs<br/>qc_ultra2, qc_prince, qc35]
     DISC --> CONN[connect&#40;&#41;]
     CFG --> CONN
 
@@ -330,8 +331,9 @@ Each catalog entry carries:
 
 ```
 lookup_device(0x4082)    → BoseDevice{wolverine, "QuietComfort Ultra Headphones (2nd Gen)", config="qc_ultra2"}
+lookup_device(0x4075)    → BoseDevice{prince, "QuietComfort Headphones", config="qc_prince"}
 is_supported(0x4024)     → False (NCH 700: recognized, no config yet)
-supported_devices()      → [wolfcastle, baywolf, edith, wolverine]
+supported_devices()      → [wolfcastle, baywolf, edith, prince, wolverine]
 known_devices()          → full catalog
 usb_ids(0x4082)          → (0x05A7, 0x4082)
 modalias(0x4082)         → "bluetooth:v05A7p4082d0000"
@@ -355,6 +357,7 @@ a default config since they don't have a tested implementation yet.
 | `0x400C` | wolfcastle | QuietComfort 35 | `qc35` |
 | `0x4020` | baywolf | QuietComfort 35 II | `qc35` |
 | `0x4062` | edith | QuietComfort Ultra Earbuds (2nd Gen) | `qc_ultra2` |
+| `0x4075` | prince | QuietComfort Headphones | `qc_prince` |
 | `0x4082` | wolverine | QuietComfort Ultra Headphones (2nd Gen) | `qc_ultra2` |
 
 ### Known Unsupported (Future Targets)
@@ -375,9 +378,10 @@ To add support for a new Bose device:
 6. **Register in the device registry** — add to `get_device()` / `DEVICES`
 7. **Set config in catalog** — change `None` to the new config key
 
-No changes to `BmapConnection` or the transport layer should be needed.
 Device-specific parsing (e.g. different ModeConfig layouts) is handled by
-assigning a different parser function in the config.
+assigning different parser and builder functions in the config. Some devices
+may still need a shared connection fallback when a newer direct-control
+feature is absent.
 
 ---
 
@@ -403,6 +407,7 @@ pybmap/
     ├── __init__.py      # Device registry (DEVICES dict, get_device())
     ├── parsers.py       # Shared parser/builder functions
     ├── qc_ultra2.py     # QC Ultra 2 config (module-level constants)
+    ├── qc_prince.py     # QuietComfort Headphones / prince config
     └── qc35.py          # QC35 config (module-level constants)
 ```
 

--- a/docs/quietcomfort-headphones-prince.md
+++ b/docs/quietcomfort-headphones-prince.md
@@ -1,0 +1,169 @@
+# QuietComfort Headphones (`prince`, `0x4075`) Protocol Notes
+
+These notes document captures from a Bose QuietComfort Headphones unit,
+codename `prince`, product ID `0x4075`, firmware
+`1.0.6-80+f5f219b`.
+
+This is not the same catalog entry as QuietComfort 45 (`duran`, `0x4039`).
+The protocol may be related, but `duran` should remain unclaimed until it is
+verified on real hardware.
+
+## Transport
+
+`prince` exposes BMAP over Bluetooth SPP. Connecting through the standard SPP
+UUID (`00001101-0000-1000-8000-00805F9B34FB`) resolves to RFCOMM channel 8 on
+the tested unit.
+
+BMAP framing is unchanged:
+
+```
+[fblock, function, flags, payload_length, ...payload]
+```
+
+The low nibble of `flags` is the operator:
+
+| Operator | Value | Direction |
+|----------|-------|-----------|
+| GET | `0x01` | read |
+| SETGET | `0x02` | write and read back |
+| STATUS | `0x03` | response |
+| ERROR | `0x04` | response |
+| START | `0x05` | action |
+| RESULT | `0x06` | response |
+
+## Mode Switching
+
+Current mode is AudioModes CurrentMode `[31.3]`.
+
+Read current mode:
+
+```
+TX: 1f 03 01 00
+RX: 1f 03 03 01 <modeIndex>
+```
+
+Switch mode:
+
+```
+TX: 1f 03 05 02 <modeIndex> <announce>
+```
+
+`announce` is `00` for silent and `01` to play the voice prompt.
+
+Observed modes on the tested unit:
+
+| Index | Prompt | Name | Editable | Raw CNC | Wind |
+|-------|--------|------|----------|---------|------|
+| 0 | `00 01` | Quiet | no | 0 | off |
+| 1 | `00 02` | Aware | no | 10 | off |
+| 2 | `00 07` | Commute | yes | 0 | on |
+| 3 | `00 0c` | Music | yes | 0-10 observed | off/on observed |
+
+Slots 2 and 3 are user-configured names on the tested unit, so only the slot
+layout and editability should be treated as protocol facts. Do not assume the
+names `Commute` and `Music` exist on every unit.
+
+## Mode Dump
+
+All mode configs are returned by starting AudioModes GetAll `[31.1]`:
+
+```
+TX: 1f 01 05 00
+RX: one or more [31.6] STATUS packets
+```
+
+Each `[31.6]` STATUS payload is 47 bytes on `prince`:
+
+| Offset | Size | Field |
+|--------|------|-------|
+| 0 | 1 | mode index |
+| 1-2 | 2 | voice prompt ID |
+| 3 | 1 | editable flag |
+| 4 | 1 | configured flag |
+| 5 | 1 | unknown flag |
+| 6-37 | 32 | mode name, UTF-8, null padded |
+| 38-40 | 3 | unknown |
+| 41 | 1 | capability/config bits, observed `0x09` |
+| 42 | 1 | raw CNC level |
+| 43 | 1 | auto CNC |
+| 44 | 1 | spatial audio field |
+| 45 | 1 | unknown |
+| 46 | 1 | wind block |
+
+This differs from QC Ultra 2's 48-byte STATUS layout. Most importantly,
+`prince` does not expose the final `ancToggle` byte at offset 47.
+
+Example decoded tail for the tested `Music` slot:
+
+```
+... 00 00 00 09 05 00 00 00 00
+            ^^ raw CNC = 5
+                     ^^ wind = 0
+```
+
+## ModeConfig SETGET
+
+`prince` writes editable mode settings with AudioModes ModeConfig `[31.6]`
+SETGET. The payload is 39 bytes:
+
+```
+1f 06 02 27 <39-byte payload>
+```
+
+Payload layout:
+
+| Offset | Size | Field |
+|--------|------|-------|
+| 0 | 1 | mode index |
+| 1-2 | 2 | voice prompt ID |
+| 3-34 | 32 | mode name, UTF-8, null padded |
+| 35 | 1 | raw CNC level |
+| 36 | 1 | auto CNC |
+| 37 | 1 | spatial audio field |
+| 38 | 1 | wind block |
+
+The raw CNC scale is inverted from a user-facing "noise cancellation strength"
+label:
+
+| Raw CNC | Audible meaning |
+|---------|-----------------|
+| 0 | maximum ANC |
+| 10 | most ambient/pass-through |
+
+If a UI wants to show "ANC strength", display `10 - rawCnc`.
+
+Captured official-app edits to the `Music` slot changed:
+
+```
+rawCnc: 10 -> 7 -> 4 -> 1 -> 0
+wind:   0 -> 1 -> 0
+```
+
+These writes applied immediately when the edited slot was the current mode.
+
+## Unsupported or Not Yet Verified
+
+The tested firmware does not support QC Ultra 2's direct live settings register:
+
+```
+[31.10] AudioModesSettingsConfig SETGET -> ERROR FuncNotSupp
+```
+
+It also rejects the newer 40-byte ModeConfig payload that includes `ancToggle`:
+
+```
+[31.6] ModeConfig SETGET, 40-byte payload -> ERROR Length
+```
+
+No unauthenticated true ANC-off toggle was found:
+
+| Attempt | Result |
+|---------|--------|
+| `[31.10]` AudioModesSettingsConfig | function not supported |
+| `[31.6]` 40-byte ModeConfig with `ancToggle` | length error |
+| `[1.6]` ANR GET | function not supported |
+| `[1.5]` SettingsCnc SETGET with disable flag | rejected/auth gated |
+
+The verified local controls are mode switching, editable-mode raw CNC level,
+and Wind Block. EQ, buttons, multipoint, power, and true ANC off remain
+unverified for `prince`.

--- a/python/pybmap/catalog.py
+++ b/python/pybmap/catalog.py
@@ -44,7 +44,7 @@ CATALOG = {
     0x402B: BoseDevice(0x402B, "beanie",     "Hearphones II",                        "headphones", None),
     0x4039: BoseDevice(0x4039, "duran",      "QuietComfort 45",                      "headphones", None),
     0x4066: BoseDevice(0x4066, "lonestarr",  "QuietComfort Ultra Headphones",        "headphones", None),
-    0x4075: BoseDevice(0x4075, "prince",     "QuietComfort Headphones",              "headphones", None),
+    0x4075: BoseDevice(0x4075, "prince",     "QuietComfort Headphones",              "headphones", "qc_prince"),
     0x4082: BoseDevice(0x4082, "wolverine",  "QuietComfort Ultra Headphones (2nd Gen)", "headphones", "qc_ultra2"),
 
     # Earbuds

--- a/python/pybmap/cli.py
+++ b/python/pybmap/cli.py
@@ -220,8 +220,8 @@ def cmd_dump(dev):
     for resp in responses:
         print(fmt_response(resp))
         if resp.fblock == 31 and resp.func == 6 and resp.op == pybmap.constants.OP_STATUS:
-            from pybmap.devices.parsers import parse_mode_config_48
-            config = parse_mode_config_48(resp.payload)
+            parser = dev._feature("mode_config").get("parser")
+            config = parser(resp.payload) if parser else None
             if config:
                 for field in config._fields:
                     if field != "raw":
@@ -383,13 +383,17 @@ def main():
             val = _parse_bool_arg(sys.argv[2:], "anc")
             if val is not None:
                 dev.set_anc(val)
-            settings = dev._get("audio_settings")
-            print("on" if settings.anc_toggle else "off")
+            if (not dev.has_feature("audio_settings") and
+                    not getattr(dev._device, "SUPPORTS_ANC_TOGGLE", True)):
+                print("unsupported")
+            else:
+                settings = dev.audio_settings()
+                print("on" if settings.anc_toggle else "off")
         elif cmd == "wind":
             val = _parse_bool_arg(sys.argv[2:], "wind")
             if val is not None:
                 dev.set_wind(val)
-            settings = dev._get("audio_settings")
+            settings = dev.audio_settings()
             print("on" if settings.wind_block else "off")
         elif cmd == "sidetone":
             if len(sys.argv) > 2:

--- a/python/pybmap/connection.py
+++ b/python/pybmap/connection.py
@@ -18,7 +18,7 @@ from .constants import (
 )
 from .protocol import bmap_packet, parse_response, parse_all_responses, fmt_response
 from .errors import BmapError, BmapAuthError, BmapDeviceError
-from .types import DeviceStatus
+from .types import DeviceStatus, AudioSettings
 
 
 class BmapConnection:
@@ -206,6 +206,25 @@ class BmapConnection:
         """
         return self._get("anr")
 
+    def audio_settings(self):
+        """Current audio settings as AudioSettings.
+
+        Newer devices expose this directly at [31.10]. Devices such as
+        QuietComfort Headphones/prince expose the same live CNC/wind fields
+        through the current editable ModeConfig instead.
+        """
+        if self.has_feature("audio_settings"):
+            return self._get("audio_settings")
+
+        config = self._current_mode_config()
+        return AudioSettings(
+            cnc_level=config.cnc_level,
+            auto_cnc=config.auto_cnc,
+            spatial=config.spatial,
+            wind_block=config.wind_block,
+            anc_toggle=config.anc_toggle,
+        )
+
     def prompts(self):
         """Voice prompts (enabled, language_name) tuple."""
         enabled, lang_id = self._get("voice_prompts")
@@ -336,7 +355,7 @@ class BmapConnection:
         the Bose app writes to. Unauthenticated on QC Ultra 2+.
         """
         if not self.has_feature("audio_settings"):
-            raise BmapError("Device does not support direct audio settings")
+            return self._update_current_mode_config(**overrides)
         settings = self._get("audio_settings")
         feat = self._feature("audio_settings")
         builder = feat["builder"]
@@ -346,6 +365,22 @@ class BmapConnection:
             wind_block=overrides.get("wind_block", settings.wind_block),
             anc_toggle=overrides.get("anc_toggle", settings.anc_toggle),
         ))
+
+    def _update_current_mode_config(self, **overrides):
+        """Fallback live audio update through the current ModeConfig."""
+        if not self.has_feature("mode_config"):
+            raise BmapError("Device does not support direct audio settings")
+
+        if ("anc_toggle" in overrides and
+                not getattr(self._device, "SUPPORTS_ANC_TOGGLE", True)):
+            raise BmapError("Device does not expose an ANC on/off toggle")
+
+        config = self._current_mode_config()
+        if not config.editable:
+            raise BmapError(
+                "Current mode '%s' is not editable on this device" % config.name
+            )
+        self._write_mode_from_config(config.mode_idx, config, **overrides)
 
     def set_name(self, new_name):
         """Set device Bluetooth name (any UTF-8 string)."""
@@ -544,6 +579,14 @@ class BmapConnection:
         # Re-read to get the full config
         modes = self.modes()
         return slot, modes.get(slot)
+
+    def _current_mode_config(self):
+        """Return ModeConfig for the current mode index."""
+        idx = self.mode_idx()
+        modes = self.modes()
+        if idx not in modes:
+            raise BmapError("Current mode config not available")
+        return modes[idx]
 
     def _find_free_slot(self, modes):
         """Find the first unconfigured editable slot."""

--- a/python/pybmap/devices/__init__.py
+++ b/python/pybmap/devices/__init__.py
@@ -2,16 +2,19 @@
 
 from . import qc_ultra2
 from . import qc35
+from . import qc_prince
 
 # Registry of supported devices keyed by type string.
 DEVICES = {
     "qc_ultra2": qc_ultra2,
     "qc35": qc35,
+    "qc_prince": qc_prince,
 }
 
 # Product ID -> device type (for auto-detection after connecting).
 PRODUCT_IDS = {
     0x4082: "qc_ultra2",
+    0x4075: "qc_prince",
     # TODO: add QC35 product ID once verified
 }
 

--- a/python/pybmap/devices/parsers.py
+++ b/python/pybmap/devices/parsers.py
@@ -310,6 +310,67 @@ def parse_mode_config_48(payload):
         )
 
 
+def parse_mode_config_47(payload):
+    """Parse ModeConfig STATUS (47 bytes) -- QuietComfort Headphones/prince.
+
+    STATUS layout observed on prince firmware 1.0.6:
+        [0]     modeIndex
+        [1:3]   voicePrompt
+        [3:6]   flags: [3]=editable, [4]=configured, [5]=unknown
+        [6:38]  modeName (32 bytes)
+        [38:41] unknown
+        [41]    capability/config bits
+        [42]    cncLevel, raw scale: 0=max ANC, 10=most ambient
+        [43]    autoCNC
+        [44]    spatialAudio
+        [45]    unknown
+        [46]    windBlock
+
+    SETGET echo layout is 39 bytes and omits the flag bytes, capability byte,
+    unknown bytes, and ancToggle byte used by newer 48-byte layouts.
+    """
+    if len(payload) < 6:
+        return None
+
+    mode_idx = payload[0]
+    prompt_b1, prompt_b2 = payload[1], payload[2]
+    prompt_name = PROMPTS.get((prompt_b1, prompt_b2), "(%d,%d)" % (prompt_b1, prompt_b2))
+
+    if len(payload) >= 47:
+        editable = bool(payload[3])
+        configured = bool(payload[4])
+        flags = "%02x %02x %02x" % (payload[3], payload[4], payload[5])
+        name = payload[6:38].split(b"\x00", 1)[0].decode("utf-8", errors="replace")
+        return ModeConfig(
+            mode_idx=mode_idx, prompt=prompt_name,
+            prompt_bytes=(prompt_b1, prompt_b2), name=name,
+            cnc_level=payload[42], auto_cnc=bool(payload[43]),
+            spatial=payload[44], wind_block=bool(payload[46]),
+            anc_toggle=False,
+            editable=editable, configured=configured, flags=flags, raw=payload,
+        )
+    elif len(payload) >= 39:
+        name = payload[3:35].split(b"\x00", 1)[0].decode("utf-8", errors="replace")
+        return ModeConfig(
+            mode_idx=mode_idx, prompt=prompt_name,
+            prompt_bytes=(prompt_b1, prompt_b2), name=name,
+            cnc_level=payload[35], auto_cnc=bool(payload[36]),
+            spatial=payload[37], wind_block=bool(payload[38]),
+            anc_toggle=False,
+            editable=True, configured=True, flags="", raw=payload,
+        )
+    else:
+        name = (payload[3:35] if len(payload) >= 35 else payload[3:])
+        name = name.split(b"\x00", 1)[0].decode("utf-8", errors="replace")
+        return ModeConfig(
+            mode_idx=mode_idx, prompt=prompt_name,
+            prompt_bytes=(prompt_b1, prompt_b2), name=name,
+            cnc_level=0, auto_cnc=False, spatial=0,
+            wind_block=False, anc_toggle=False,
+            editable=False, configured=False, flags="", raw=payload,
+        )
+
+
 def parse_audio_settings(payload):
     """Parse AudioModesSettingsConfig [31.10] STATUS response (5 bytes)."""
     if len(payload) < 5:
@@ -349,4 +410,20 @@ def build_mode_config_40(mode_idx, name, cnc_level=0, auto_cnc=False,
     payload.append(spatial)
     payload.append(1 if wind_block else 0)
     payload.append(1 if anc_toggle else 0)
+    return bytes(payload)
+
+
+def build_mode_config_39(mode_idx, name, cnc_level=0, auto_cnc=False,
+                         spatial=0, wind_block=1, anc_toggle=1,
+                         prompt_b1=0, prompt_b2=0):
+    """Build 39-byte ModeConfig SETGET payload -- prince / 47-byte STATUS."""
+    payload = bytearray()
+    payload.append(mode_idx)
+    payload.append(prompt_b1)
+    payload.append(prompt_b2)
+    payload.extend(encode_mode_name(name))
+    payload.append(cnc_level)
+    payload.append(1 if auto_cnc else 0)
+    payload.append(spatial)
+    payload.append(1 if wind_block else 0)
     return bytes(payload)

--- a/python/pybmap/devices/qc_prince.py
+++ b/python/pybmap/devices/qc_prince.py
@@ -1,0 +1,93 @@
+"""Bose QuietComfort Headphones device configuration.
+
+Codename "prince", product ID 0x4075.
+Verified against real hardware on firmware 1.0.6-80+f5f219b.
+
+BMAP is exposed over the standard SPP UUID and resolves to RFCOMM channel 8.
+The AudioModes block is close to QC Ultra 2 but uses a shorter ModeConfig
+layout: 47-byte STATUS responses and 39-byte SETGET payloads. The final
+ancToggle byte present on newer 48/40-byte layouts is not supported here.
+"""
+
+from . import parsers
+
+RFCOMM_CHANNEL = 8
+SUPPORTS_ANC_TOGGLE = False
+
+# ── Device Identity ──────────────────────────────────────────────────────────
+
+DEVICE_INFO = {
+    "name": "Bose QuietComfort Headphones",
+    "codename": "prince",
+    "platform": "Unknown",
+    "product_id": 0x4075,
+    "variant": 0x00,
+}
+
+# ── Feature Map ──────────────────────────────────────────────────────────────
+
+FEATURES = {
+    "battery": {
+        "addr": (2, 2),
+        "parser": parsers.parse_battery,
+    },
+    "firmware": {
+        "addr": (0, 5),
+        "parser": parsers.parse_firmware,
+    },
+    "product_name": {
+        "addr": (1, 2),
+        "parser": parsers.parse_product_name,
+    },
+    "voice_prompts": {
+        "addr": (1, 3),
+        "parser": parsers.parse_voice_prompts,
+        "builder": parsers.build_voice_prompts,
+    },
+    "cnc": {
+        "addr": (1, 5),
+        "parser": parsers.parse_cnc,
+    },
+    "pairing": {
+        "addr": (4, 8),
+    },
+    # AudioModes block (31)
+    "get_all_modes": {
+        "addr": (31, 1),
+    },
+    "current_mode": {
+        "addr": (31, 3),
+    },
+    "mode_config": {
+        "addr": (31, 6),
+        "parser": parsers.parse_mode_config_47,
+        "builder": parsers.build_mode_config_39,
+    },
+}
+
+# ── Mode Configuration ───────────────────────────────────────────────────────
+
+# The first two slots are built-in presets. Later slots are user-named modes
+# on the paired device; do not assume their names are universal.
+PRESET_MODES = {
+    "quiet": {"idx": 0, "description": "Quiet - full ANC"},
+    "aware": {"idx": 1, "description": "Aware - transparency"},
+}
+
+MODE_BY_IDX = {m["idx"]: name for name, m in PRESET_MODES.items()}
+
+# Observed configured editable slots on the tested unit. Other firmware may
+# expose different user mode names, but the 47/39-byte payload layout is the
+# important protocol difference.
+EDITABLE_SLOTS = [2, 3]
+
+STATUS_OFFSETS = {
+    "prompt_b1": 1,
+    "prompt_b2": 2,
+    "editable": 3,
+    "configured": 4,
+    "cnc_level": 42,
+    "auto_cnc": 43,
+    "spatial": 44,
+    "wind_block": 46,
+}

--- a/python/tests/test_catalog.py
+++ b/python/tests/test_catalog.py
@@ -30,6 +30,12 @@ class TestLookup:
         assert dev.codename == "edith"
         assert dev.config == "qc_ultra2"
 
+    def test_quietcomfort_headphones_prince(self):
+        dev = lookup_device(0x4075)
+        assert dev.codename == "prince"
+        assert dev.name == "QuietComfort Headphones"
+        assert dev.config == "qc_prince"
+
     def test_unsupported_known(self):
         dev = lookup_device(0x4024)
         assert dev is not None
@@ -44,6 +50,7 @@ class TestSupport:
     def test_is_supported(self):
         assert is_supported(0x4082)  # wolverine
         assert is_supported(0x4062)  # edith
+        assert is_supported(0x4075)  # prince
         assert is_supported(0x4020)  # baywolf
         assert is_supported(0x400C)  # wolfcastle
 
@@ -53,7 +60,7 @@ class TestSupport:
 
     def test_supported_devices(self):
         devs = supported_devices()
-        assert len(devs) >= 4  # wolfcastle, baywolf, edith, wolverine
+        assert len(devs) >= 5  # wolfcastle, baywolf, edith, prince, wolverine
         assert all(d.config is not None for d in devs)
 
     def test_known_devices(self):

--- a/python/tests/test_connection.py
+++ b/python/tests/test_connection.py
@@ -3,9 +3,9 @@
 import pytest
 from pybmap.connection import BmapConnection
 from pybmap.protocol import bmap_packet
-from pybmap.constants import OP_GET, OP_STATUS, OP_RESULT, OP_ERROR
+from pybmap.constants import OP_GET, OP_SETGET, OP_STATUS, OP_RESULT, OP_ERROR
 from pybmap.errors import BmapError, BmapAuthError, BmapDeviceError
-from pybmap.devices import qc_ultra2
+from pybmap.devices import qc_ultra2, qc_prince
 
 
 class MockTransport:
@@ -160,6 +160,51 @@ class TestPublicAPI:
         with BmapConnection(transport, qc_ultra2) as dev:
             assert dev.battery() == 70
         assert transport.closed is True
+
+
+class TestPrinceAudioModes:
+    MUSIC_MODE = bytes.fromhex(
+        "03000c0101004d757369630000000000000000000000000000000000"
+        "00000000000000000000000000090500000000"
+    )
+
+    def test_audio_settings_fallback_reads_current_mode(self):
+        transport = MockTransport()
+        transport.add_response(31, 3, OP_STATUS, bytes([3]))
+        transport.responses[(31, 1)] = (
+            bytes([31, 6, OP_STATUS, len(self.MUSIC_MODE)]) + self.MUSIC_MODE
+        )
+        dev = BmapConnection(transport, qc_prince)
+
+        settings = dev.audio_settings()
+
+        assert settings.cnc_level == 5
+        assert settings.wind_block is False
+        assert settings.anc_toggle is False
+
+    def test_set_wind_fallback_writes_39_byte_mode_config(self):
+        transport = MockTransport()
+        transport.add_response(31, 3, OP_STATUS, bytes([3]))
+        transport.responses[(31, 1)] = (
+            bytes([31, 6, OP_STATUS, len(self.MUSIC_MODE)]) + self.MUSIC_MODE
+        )
+        transport.add_response(31, 6, OP_STATUS, self.MUSIC_MODE)
+        dev = BmapConnection(transport, qc_prince)
+
+        dev.set_wind(True)
+
+        sent = transport.sent[-1]
+        assert sent[:4] == bytes([31, 6, OP_SETGET, 39])
+        assert sent[4] == 3
+        assert sent[4 + 35] == 5
+        assert sent[4 + 38] == 1
+
+    def test_set_anc_fallback_rejects_unsupported_toggle(self):
+        transport = MockTransport()
+        dev = BmapConnection(transport, qc_prince)
+
+        with pytest.raises(BmapError, match="ANC on/off"):
+            dev.set_anc(False)
 
 
 class TestErrorHandling:

--- a/python/tests/test_device_parsers.py
+++ b/python/tests/test_device_parsers.py
@@ -4,7 +4,8 @@ from pybmap.devices.parsers import (
     parse_battery, parse_firmware, parse_product_name, parse_cnc,
     parse_eq, parse_buttons, parse_multipoint, parse_bool,
     parse_sidetone, parse_voice_prompts,
-    parse_mode_config_48, build_mode_config_40,
+    parse_mode_config_48, parse_mode_config_47,
+    build_mode_config_40, build_mode_config_39,
     build_eq_band, build_toggle, build_sidetone, build_voice_prompts,
     build_buttons,
 )
@@ -245,6 +246,34 @@ class TestBuildModeConfig:
         assert config.wind_block is True
         assert config.anc_toggle is True
 
+    def test_prince_payload_length(self):
+        payload = build_mode_config_39(
+            mode_idx=3, name="Music", cnc_level=5,
+            spatial=0, wind_block=1, prompt_b1=0, prompt_b2=12,
+        )
+        assert len(payload) == 39
+        assert payload[0] == 3
+        assert payload[1] == 0
+        assert payload[2] == 12
+        assert payload[3:8] == b"Music"
+        assert payload[35] == 5
+        assert payload[36] == 0
+        assert payload[37] == 0
+        assert payload[38] == 1
+
+    def test_prince_roundtrip_39(self):
+        payload = build_mode_config_39(
+            mode_idx=2, name="Commute", cnc_level=0,
+            spatial=0, wind_block=1, prompt_b1=0, prompt_b2=7,
+        )
+        config = parse_mode_config_47(payload)
+        assert config is not None
+        assert config.mode_idx == 2
+        assert config.name == "Commute"
+        assert config.cnc_level == 0
+        assert config.wind_block is True
+        assert config.anc_toggle is False
+
 
 class TestParseModeConfig48:
     def test_too_short(self):
@@ -256,6 +285,39 @@ class TestParseModeConfig48:
         config = parse_mode_config_48(payload)
         assert config is not None
         assert config.mode_idx == 5
+
+
+class TestParseModeConfig47:
+    def test_from_prince_music_capture(self):
+        payload = bytes.fromhex(
+            "03000c0101004d757369630000000000000000000000000000000000"
+            "00000000000000000000000000090500000000"
+        )
+        config = parse_mode_config_47(payload)
+        assert config is not None
+        assert config.mode_idx == 3
+        assert config.prompt_bytes == (0, 12)
+        assert config.name == "Music"
+        assert config.editable is True
+        assert config.configured is True
+        assert config.cnc_level == 5
+        assert config.auto_cnc is False
+        assert config.spatial == 0
+        assert config.wind_block is False
+        assert config.anc_toggle is False
+
+    def test_from_prince_commute_capture(self):
+        payload = bytes.fromhex(
+            "020007010100436f6d6d757465000000000000000000000000000000"
+            "00000000000000000000000000090000000001"
+        )
+        config = parse_mode_config_47(payload)
+        assert config is not None
+        assert config.mode_idx == 2
+        assert config.prompt_bytes == (0, 7)
+        assert config.name == "Commute"
+        assert config.cnc_level == 0
+        assert config.wind_block is True
 
 
 # ── Builder Tests ────────────────────────────────────────────────────────────

--- a/python/tests/test_qc_ultra2.py
+++ b/python/tests/test_qc_ultra2.py
@@ -1,6 +1,6 @@
 """Tests for QC Ultra 2 device configuration."""
 
-from pybmap.devices import qc_ultra2, DEVICES, get_device
+from pybmap.devices import qc_ultra2, qc_prince, DEVICES, get_device
 
 
 class TestDeviceRegistry:
@@ -9,6 +9,9 @@ class TestDeviceRegistry:
 
     def test_qc35_registered(self):
         assert "qc35" in DEVICES
+
+    def test_qc_prince_registered(self):
+        assert "qc_prince" in DEVICES
 
     def test_get_device(self):
         dev = get_device("qc_ultra2")
@@ -71,6 +74,27 @@ class TestQCUltra2Config:
         mc = qc_ultra2.FEATURES["mode_config"]
         assert mc["parser"] is not None
         assert mc["builder"] is not None
+
+
+class TestQCPrinceConfig:
+    def test_has_device_info(self):
+        assert qc_prince.DEVICE_INFO["codename"] == "prince"
+        assert qc_prince.DEVICE_INFO["product_id"] == 0x4075
+
+    def test_uses_channel_8(self):
+        assert qc_prince.RFCOMM_CHANNEL == 8
+
+    def test_no_audio_settings(self):
+        assert "audio_settings" not in qc_prince.FEATURES
+
+    def test_mode_config_has_prince_parser_and_builder(self):
+        mc = qc_prince.FEATURES["mode_config"]
+        assert mc["parser"] is not None
+        assert mc["builder"] is not None
+
+    def test_no_anc_toggle(self):
+        assert qc_prince.SUPPORTS_ANC_TOGGLE is False
+        assert "anc_toggle" not in qc_prince.STATUS_OFFSETS
 
 
 class TestQC35Config:

--- a/rust/src/catalog.rs
+++ b/rust/src/catalog.rs
@@ -40,7 +40,7 @@ pub const CATALOG: &[BoseDevice] = &[
     BoseDevice { product_id: 0x402B, codename: "beanie",     name: "Hearphones II",                          category: Category::Headphones, config: None },
     BoseDevice { product_id: 0x4039, codename: "duran",      name: "QuietComfort 45",                        category: Category::Headphones, config: None },
     BoseDevice { product_id: 0x4066, codename: "lonestarr",  name: "QuietComfort Ultra Headphones",          category: Category::Headphones, config: None },
-    BoseDevice { product_id: 0x4075, codename: "prince",     name: "QuietComfort Headphones",                category: Category::Headphones, config: None },
+    BoseDevice { product_id: 0x4075, codename: "prince",     name: "QuietComfort Headphones",                category: Category::Headphones, config: Some("qc_prince") },
     BoseDevice { product_id: 0x4082, codename: "wolverine",  name: "QuietComfort Ultra Headphones (2nd Gen)", category: Category::Headphones, config: Some("qc_ultra2") },
     // Earbuds
     BoseDevice { product_id: 0x4012, codename: "ice",        name: "SoundSport",                             category: Category::Earbuds, config: None },
@@ -134,6 +134,13 @@ mod tests {
     }
 
     #[test]
+    fn test_lookup_qc_prince() {
+        let dev = lookup_device(0x4075).unwrap();
+        assert_eq!(dev.codename, "prince");
+        assert_eq!(dev.config, Some("qc_prince"));
+    }
+
+    #[test]
     fn test_lookup_unknown() {
         assert!(lookup_device(0xFFFF).is_none());
     }
@@ -142,6 +149,7 @@ mod tests {
     fn test_is_supported() {
         assert!(is_supported(0x4082)); // wolverine
         assert!(is_supported(0x4062)); // edith
+        assert!(is_supported(0x4075)); // prince
         assert!(is_supported(0x4020)); // baywolf
         assert!(is_supported(0x400C)); // wolfcastle
         assert!(!is_supported(0x4024)); // NCH 700, no config

--- a/rust/src/connection.rs
+++ b/rust/src/connection.rs
@@ -357,30 +357,43 @@ impl<T: Transport> BmapConnection<T> {
 
     /// Read current audio settings as 5-tuple: (cnc, auto_cnc, spatial, wind, anc).
     pub fn audio_settings(&self) -> BmapResult<(u8, u8, u8, u8, u8)> {
-        let addr = self.addr(self.config.audio_settings)?;
-        let p = self.get(addr)?;
-        Ok((
-            p.first().copied().unwrap_or(0),
-            p.get(1).copied().unwrap_or(0),
-            p.get(2).copied().unwrap_or(0),
-            p.get(3).copied().unwrap_or(1),
-            p.get(4).copied().unwrap_or(1),
-        ))
+        if let Some(addr) = self.config.audio_settings {
+            let p = self.get(addr)?;
+            Ok((
+                p.first().copied().unwrap_or(0),
+                p.get(1).copied().unwrap_or(0),
+                p.get(2).copied().unwrap_or(0),
+                p.get(3).copied().unwrap_or(1),
+                p.get(4).copied().unwrap_or(1),
+            ))
+        } else {
+            let mc = self.current_mode_config()?;
+            Ok((
+                mc.cnc_level,
+                0,
+                mc.spatial,
+                if mc.wind_block { 1 } else { 0 },
+                if mc.anc_toggle { 1 } else { 0 },
+            ))
+        }
     }
 
     fn update_audio_settings(&self, cnc: Option<u8>, spatial: Option<u8>,
                               wind: Option<bool>, anc: Option<bool>) -> BmapResult<()> {
-        let addr = self.addr(self.config.audio_settings)?;
-        let cur = self.get(addr)?;
-        let payload = [
-            cnc.unwrap_or(cur.first().copied().unwrap_or(0)),
-            cur.get(1).copied().unwrap_or(0),  // auto_cnc
-            spatial.unwrap_or(cur.get(2).copied().unwrap_or(0)),
-            wind.map(|b| if b { 1 } else { 0 }).unwrap_or(cur.get(3).copied().unwrap_or(1)),
-            anc.map(|b| if b { 1 } else { 0 }).unwrap_or(cur.get(4).copied().unwrap_or(1)),
-        ];
-        self.setget(addr, &payload)?;
-        Ok(())
+        if let Some(addr) = self.config.audio_settings {
+            let cur = self.get(addr)?;
+            let payload = [
+                cnc.unwrap_or(cur.first().copied().unwrap_or(0)),
+                cur.get(1).copied().unwrap_or(0),  // auto_cnc
+                spatial.unwrap_or(cur.get(2).copied().unwrap_or(0)),
+                wind.map(|b| if b { 1 } else { 0 }).unwrap_or(cur.get(3).copied().unwrap_or(1)),
+                anc.map(|b| if b { 1 } else { 0 }).unwrap_or(cur.get(4).copied().unwrap_or(1)),
+            ];
+            self.setget(addr, &payload)?;
+            Ok(())
+        } else {
+            self.update_current_mode_config(cnc, spatial, wind, anc)
+        }
     }
 
     /// Toggle voice prompts. Preserves current language.
@@ -530,11 +543,46 @@ impl<T: Transport> BmapConnection<T> {
         })
     }
 
+    fn current_mode_config(&self) -> BmapResult<ModeConfig> {
+        let idx = self.mode_idx()?;
+        let modes = self.modes()?;
+        modes.into_iter()
+            .find(|m| m.mode_idx == idx)
+            .ok_or_else(|| BmapError::Device {
+                message: "Current mode config not available".into(), code: 0,
+            })
+    }
+
+    fn update_current_mode_config(&self, cnc: Option<u8>, spatial: Option<u8>,
+                                  wind: Option<bool>, anc: Option<bool>) -> BmapResult<()> {
+        if anc.is_some() && !self.config.supports_anc_toggle {
+            return Err(BmapError::Unsupported(
+                "Device does not expose an ANC on/off toggle".into()
+            ));
+        }
+        let mut mc = self.current_mode_config()?;
+        if !mc.editable {
+            return Err(BmapError::Unsupported(
+                format!("Current mode '{}' is not editable on this device", mc.name)
+            ));
+        }
+        if let Some(v) = cnc { mc.cnc_level = v; }
+        if let Some(v) = spatial { mc.spatial = v; }
+        if let Some(v) = wind { mc.wind_block = v; }
+        if let Some(v) = anc { mc.anc_toggle = v; }
+        self.write_mode(
+            mc.mode_idx, &mc.name, mc.cnc_level, mc.spatial,
+            mc.wind_block, mc.anc_toggle, mc.prompt_b1, mc.prompt_b2,
+        )
+    }
+
     fn write_mode(&self, slot: u8, name: &str, cnc_level: u8, spatial: u8,
                    wind_block: bool, anc_toggle: bool, prompt_b1: u8, prompt_b2: u8)
                    -> BmapResult<()> {
         let addr = self.addr(self.config.mode_config)?;
-        let payload = build_mode_config_40(
+        let builder = self.config.build_mode_config
+            .ok_or_else(|| BmapError::Unsupported("Device has no mode config builder".into()))?;
+        let payload = builder(
             slot, name, cnc_level, spatial, wind_block, anc_toggle, prompt_b1, prompt_b2,
         );
         let data = self.transport.send_recv_drain(
@@ -806,5 +854,37 @@ mod tests {
         let dev = BmapConnection::new(t, devices::qc_ultra2());
         // "nonexistent" is not a preset, and modes() will fail (no mock for get_all_modes)
         assert!(dev.set_mode("nonexistent", false).is_err());
+    }
+
+    #[test]
+    fn test_prince_set_wind_uses_mode_config_fallback() {
+        let music = vec![
+            0x03,0x00,0x0c,0x01,0x01,0x00,0x4d,0x75,0x73,0x69,0x63,0x00,0x00,0x00,0x00,0x00,
+            0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+            0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x09,0x05,0x00,0x00,0x00,0x00,
+        ];
+        let mut t = MockTransport::new();
+        t.add(31, 3, 0x03, &[3]); // current mode: Music
+        let mut get_all = vec![31, 6, 0x03, music.len() as u8];
+        get_all.extend_from_slice(&music);
+        t.responses.insert((31, 1), get_all);
+        t.add(31, 6, 0x03, &music);
+        let dev = BmapConnection::new(t, devices::qc_prince());
+
+        assert!(dev.set_wind(true).is_ok());
+
+        let sent = dev.transport.sent.borrow();
+        let last = sent.last().unwrap();
+        assert_eq!(&last[..4], &[31, 6, 0x02, 39]);
+        assert_eq!(last[4], 3);
+        assert_eq!(last[4 + 35], 5);
+        assert_eq!(last[4 + 38], 1);
+    }
+
+    #[test]
+    fn test_prince_set_anc_rejects_missing_toggle() {
+        let t = MockTransport::new();
+        let dev = BmapConnection::new(t, devices::qc_prince());
+        assert!(dev.set_anc(false).is_err());
     }
 }

--- a/rust/src/device.rs
+++ b/rust/src/device.rs
@@ -120,6 +120,10 @@ pub struct DeviceConfig {
     pub editable_slots: &'static [u8],
     /// Device-specific ModeConfig STATUS parser. None if device has no mode config.
     pub parse_mode_config: Option<fn(&[u8]) -> Option<ModeConfig>>,
+    /// Device-specific ModeConfig SETGET builder.
+    pub build_mode_config: Option<fn(u8, &str, u8, u8, bool, bool, u8, u8) -> Vec<u8>>,
+    /// Whether the ModeConfig or audio settings layout exposes an ANC toggle bit.
+    pub supports_anc_toggle: bool,
 }
 
 // ── Shared Parsers ──────────────────────────────────────────────────────────
@@ -455,6 +459,60 @@ pub fn parse_mode_config_qc_ultra2(payload: &[u8]) -> Option<ModeConfig> {
     }
 }
 
+/// Parse a 47-byte ModeConfig STATUS response (QuietComfort Headphones/prince).
+///
+/// STATUS offsets: CNC=42, spatial=44, wind=46. No anc_toggle byte.
+/// SETGET echo format is 39 bytes: CNC=35, spatial=37, wind=38.
+pub fn parse_mode_config_prince(payload: &[u8]) -> Option<ModeConfig> {
+    if payload.len() < 6 {
+        return None;
+    }
+
+    let mode_idx = payload[0];
+    let prompt_b1 = payload[1];
+    let prompt_b2 = payload[2];
+
+    if payload.len() >= 47 {
+        let editable = payload[3] != 0;
+        let configured = payload[4] != 0;
+        let name_bytes = &payload[6..38];
+        let name_end = name_bytes.iter().position(|&b| b == 0).unwrap_or(32);
+        let name = String::from_utf8_lossy(&name_bytes[..name_end]).into_owned();
+
+        Some(ModeConfig {
+            mode_idx,
+            name,
+            cnc_level: payload[42],
+            spatial: payload[44],
+            wind_block: payload[46] != 0,
+            anc_toggle: false,
+            editable,
+            configured,
+            prompt_b1,
+            prompt_b2,
+        })
+    } else if payload.len() >= 39 {
+        let name_bytes = &payload[3..35];
+        let name_end = name_bytes.iter().position(|&b| b == 0).unwrap_or(32);
+        let name = String::from_utf8_lossy(&name_bytes[..name_end]).into_owned();
+
+        Some(ModeConfig {
+            mode_idx,
+            name,
+            cnc_level: payload[35],
+            spatial: payload[37],
+            wind_block: payload[38] != 0,
+            anc_toggle: false,
+            editable: true,
+            configured: true,
+            prompt_b1,
+            prompt_b2,
+        })
+    } else {
+        None
+    }
+}
+
 /// Build a 40-byte ModeConfig SETGET payload.
 pub fn build_mode_config_40(
     mode_idx: u8, name: &str, cnc_level: u8, spatial: u8,
@@ -470,6 +528,23 @@ pub fn build_mode_config_40(
     payload.push(spatial);
     payload.push(if wind_block { 1 } else { 0 });
     payload.push(if anc_toggle { 1 } else { 0 });
+    payload
+}
+
+/// Build a 39-byte ModeConfig SETGET payload (QuietComfort Headphones/prince).
+pub fn build_mode_config_39(
+    mode_idx: u8, name: &str, cnc_level: u8, spatial: u8,
+    wind_block: bool, _anc_toggle: bool, prompt_b1: u8, prompt_b2: u8,
+) -> Vec<u8> {
+    let mut payload = Vec::with_capacity(39);
+    payload.push(mode_idx);
+    payload.push(prompt_b1);
+    payload.push(prompt_b2);
+    payload.extend_from_slice(&encode_mode_name(name));
+    payload.push(cnc_level);
+    payload.push(0); // auto_cnc
+    payload.push(spatial);
+    payload.push(if wind_block { 1 } else { 0 });
     payload
 }
 
@@ -570,5 +645,33 @@ mod tests {
         assert_eq!(payload[37], 2);  // spatial
         assert_eq!(payload[38], 1);  // wind_block
         assert_eq!(payload[39], 1);  // anc_toggle
+    }
+
+    #[test]
+    fn test_build_mode_config_39() {
+        let payload = build_mode_config_39(3, "Music", 5, 0, true, false, 0, 12);
+        assert_eq!(payload.len(), 39);
+        assert_eq!(payload[0], 3);
+        assert_eq!(payload[1], 0);
+        assert_eq!(payload[2], 12);
+        assert_eq!(&payload[3..8], b"Music");
+        assert_eq!(payload[35], 5);
+        assert_eq!(payload[38], 1);
+    }
+
+    #[test]
+    fn test_parse_mode_config_prince_capture() {
+        let payload = vec![
+            0x03,0x00,0x0c,0x01,0x01,0x00,0x4d,0x75,0x73,0x69,0x63,0x00,0x00,0x00,0x00,0x00,
+            0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+            0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x09,0x05,0x00,0x00,0x00,0x00,
+        ];
+        let mc = parse_mode_config_prince(&payload).unwrap();
+        assert_eq!(mc.mode_idx, 3);
+        assert_eq!(mc.prompt_b2, 12);
+        assert_eq!(mc.name, "Music");
+        assert_eq!(mc.cnc_level, 5);
+        assert!(!mc.wind_block);
+        assert!(!mc.anc_toggle);
     }
 }

--- a/rust/src/devices.rs
+++ b/rust/src/devices.rs
@@ -1,6 +1,10 @@
 //! Device configurations.
 
-use crate::device::{Addr, DeviceConfig, DeviceInfo, PresetMode, parse_mode_config_qc_ultra2};
+use crate::device::{
+    Addr, DeviceConfig, DeviceInfo, PresetMode,
+    build_mode_config_39, build_mode_config_40,
+    parse_mode_config_prince, parse_mode_config_qc_ultra2,
+};
 
 /// Bose QC Ultra 2 configuration.
 pub fn qc_ultra2() -> DeviceConfig {
@@ -41,6 +45,52 @@ pub fn qc_ultra2() -> DeviceConfig {
         ],
         editable_slots: &[4, 5, 6, 7, 8, 9, 10],
         parse_mode_config: Some(parse_mode_config_qc_ultra2),
+        build_mode_config: Some(build_mode_config_40),
+        supports_anc_toggle: true,
+    }
+}
+
+/// Bose QuietComfort Headphones configuration -- prince, product ID 0x4075.
+/// Verified against firmware 1.0.6-80+f5f219b.
+/// BMAP over RFCOMM channel 8 with 47-byte ModeConfig STATUS responses.
+pub fn qc_prince() -> DeviceConfig {
+    DeviceConfig {
+        info: DeviceInfo {
+            name: "Bose QuietComfort Headphones",
+            codename: "prince",
+            platform: "Unknown",
+        },
+        rfcomm_channel: 8,
+        init_packet: None,
+        battery: Some(Addr(2, 2)),
+        firmware: Some(Addr(0, 5)),
+        product_name: Some(Addr(1, 2)),
+        voice_prompts: Some(Addr(1, 3)),
+        cnc: Some(Addr(1, 5)),
+        eq: None,
+        buttons: None,
+        multipoint: None,
+        sidetone: None,
+        auto_pause: None,
+        auto_answer: None,
+        anr: None,
+        pairing: Some(Addr(4, 8)),
+        routing: None,
+        source: None,
+        power: None,
+        get_all_modes: Some(Addr(31, 1)),
+        current_mode: Some(Addr(31, 3)),
+        mode_config: Some(Addr(31, 6)),
+        favorites: None,
+        audio_settings: None,
+        preset_modes: &[
+            ("quiet", PresetMode { idx: 0, description: "Quiet - full ANC" }),
+            ("aware", PresetMode { idx: 1, description: "Aware - transparency" }),
+        ],
+        editable_slots: &[2, 3],
+        parse_mode_config: Some(parse_mode_config_prince),
+        build_mode_config: Some(build_mode_config_39),
+        supports_anc_toggle: false,
     }
 }
 
@@ -85,6 +135,8 @@ pub fn qc35() -> DeviceConfig {
         ],
         editable_slots: &[],
         parse_mode_config: None,
+        build_mode_config: None,
+        supports_anc_toggle: false,
     }
 }
 
@@ -93,6 +145,7 @@ pub fn get_device(name: &str) -> Option<DeviceConfig> {
     match name {
         "qc_ultra2" => Some(qc_ultra2()),
         "qc35" => Some(qc35()),
+        "qc_prince" => Some(qc_prince()),
         _ => None,
     }
 }
@@ -109,6 +162,18 @@ mod tests {
         assert!(dev.mode_config.is_some());
         assert_eq!(dev.preset_modes.len(), 4);
         assert_eq!(dev.editable_slots.len(), 7);
+        assert!(dev.build_mode_config.is_some());
+    }
+
+    #[test]
+    fn test_qc_prince_channel_and_mode_layout() {
+        let dev = qc_prince();
+        assert_eq!(dev.info.codename, "prince");
+        assert_eq!(dev.rfcomm_channel, 8);
+        assert!(dev.mode_config.is_some());
+        assert!(dev.audio_settings.is_none());
+        assert!(!dev.supports_anc_toggle);
+        assert_eq!(dev.editable_slots, &[2, 3]);
     }
 
     #[test]
@@ -123,6 +188,7 @@ mod tests {
     fn test_get_device() {
         assert!(get_device("qc_ultra2").is_some());
         assert!(get_device("qc35").is_some());
+        assert!(get_device("qc_prince").is_some());
         assert!(get_device("nonexistent").is_none());
     }
 }

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -137,9 +137,13 @@ fn main() {
                     return err_exit(&e);
                 }
             }
-            dev.audio_settings().map(|(_, _, _, _, anc)| {
-                println!("{}", if anc != 0 { "on" } else { "off" });
-            })
+            if dev.config().audio_settings.is_none() && !dev.config().supports_anc_toggle {
+                Ok(println!("unsupported"))
+            } else {
+                dev.audio_settings().map(|(_, _, _, _, anc)| {
+                    println!("{}", if anc != 0 { "on" } else { "off" });
+                })
+            }
         }
         "wind" => {
             if args.len() > 2 {
@@ -322,5 +326,5 @@ fn usage() {
     println!();
     println!("Environment:");
     println!("  BMAP_MAC=XX:XX:XX:XX:XX:XX   Device MAC (auto-detected if unset)");
-    println!("  BMAP_DEVICE=qc_ultra2         Device type (default: qc_ultra2)");
+    println!("  BMAP_DEVICE=qc_ultra2|qc_prince|qc35   Device type");
 }


### PR DESCRIPTION
## Summary

- Add `qc_prince` support for Bose QuietComfort Headphones (`prince`, product ID `0x4075`) across Python, Rust, and C++ catalogs/configs.
- Add the 47-byte ModeConfig STATUS parser and 39-byte ModeConfig SETGET builder used by this device.
- Add a ModeConfig fallback for live CNC/wind updates when `[31.10] AudioModesSettingsConfig` is not available.
- Document the observed protocol, including RFCOMM channel 8, mode switching packets, raw CNC scale, wind block, and unsupported ANC-off attempts.

## Notes

This is intentionally separate from QuietComfort 45 (`duran`, `0x4039`), which remains unverified.

## Testing

- `python/.venv/Scripts/python.exe -m pytest python/tests -q` -> `134 passed, 18 skipped`
- `git diff --check` -> clean, aside from existing line-ending warnings on Windows
- Rust tests were not run: `cargo`/`rustc` are not installed in this Windows environment.
- C++ build was attempted with CMake/MSVC, but this repo's C++ target depends on Linux/BlueZ headers (`bluetooth/bluetooth.h`) and POSIX `popen/pclose`, so it cannot build in this Windows environment.