### PR TITLE
Add QC Ultra 2 Earbuds support

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -21,6 +21,34 @@ the app uses to change modes in real time.
 - Custom name: "Fargo"
 - Product ID: 0x4082, Variant: 0x01
 
+## QC Ultra 2 Earbuds — EDITH
+
+- Product: Bose QuietComfort Ultra Earbuds (2nd Gen)
+- Codename: `edith`
+- Product ID: `0x4062`
+- Platform: OTG-QCC-384
+- Transport: Bluetooth SPP over RFCOMM channel 2
+- Feature layout: shared with QC Ultra 2 headphones
+- Hardware validation: physical `edith` device; battery components, status,
+  listening modes, and CNC behavior verified
+
+### Component Battery Response
+
+EDITH returns multiple four-byte battery records from `[2.2]`. Each record is
+`[level, reserved, reserved, component_id]`:
+
+| Component ID | Component | Example |
+|--------------|-----------|---------|
+| `0x01` | Right | `3cffff01` = 60% |
+| `0x02` | Left | `3cffff02` = 60% |
+| `0x03` | Case | `50ffff03` = 80% |
+| `0x04` | Combined buds | `3cffff04` = 60%, used for generic Battery |
+
+Records must be identified by component ID, not payload position. The generic
+`Battery` value uses ID `0x04`; the CLI separately displays IDs `0x01`, `0x02`,
+and `0x03`. BMAP `[2.5]` tracks whether both earbuds are seated and did not
+change across observed charger transitions, so case charging is not inferred.
+
 ## BMAP Protocol
 - Version: 1.1.0
 - Transport: Bluetooth SPP over RFCOMM channel 2

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Release](https://img.shields.io/github/v/release/aaronsb/bosectl)](https://github.com/aaronsb/bosectl/releases/latest)
-[![Devices](https://img.shields.io/badge/Devices-3_supported_·_38_known-green)](docs/architecture.md#device-catalog)
+[![Devices](https://img.shields.io/badge/Devices-8_supported_·_38_known-green)](docs/architecture.md#device-catalog)
 [![Python 3](https://img.shields.io/badge/Python-3-3572A5.svg)](python/)
 [![Rust](https://img.shields.io/badge/Rust-1.70+-DEA584.svg)](rust/)
 [![C++17](https://img.shields.io/badge/C++-17-f34b7d.svg)](cpp/)
@@ -26,6 +26,7 @@ connection to the headphones.
 | Device                      | NC Control                            | EQ     | Spatial        | Profiles              | Buttons                | Status             |
 | --------------------------- | ------------------------------------- | ------ | -------------- | --------------------- | ---------------------- | ------------------ |
 | **QC Ultra Headphones 2**   | CNC 0-10 slider                       | 3-band | room/head      | 7 custom slots        | Shortcut remap         | Verified           |
+| **QC Ultra Earbuds 2**      | CNC 0-10 (verified)                   | inherited | modes verified | inherited           | inherited              | Battery/status/modes/CNC verified (`edith`) |
 | **QuietComfort Headphones** | CNC 0-10 + Wind Block via ModeConfig  | —      | field observed | 2 user slots observed | —                      | Verified (`prince`) |
 | **QuietComfort 35 / 35 II** | ANR off/high/wind/low                 | —      | —              | —                     | Action remap (VPA/ANC) | Verified           |
 | **QuietComfort Earbuds**    | CNC 0-10 via direct SETGET            | 3-band | —              | 4 fixed modes         | Remap                  | Verified (`lando`) |
@@ -97,6 +98,10 @@ bosectl buttons set ANC     # Remap programmable button
 bosectl quiet               # Switch to Quiet mode
 ```
 
+When `BMAP_MAC` (or Python CLI alias `BOSE_MAC`) is set, also set
+`BMAP_DEVICE` to the matching config key. Device type is auto-detected only
+when the MAC address is auto-detected.
+
 ### Device Catalog API
 
 ```python
@@ -114,8 +119,8 @@ pybmap.modalias(0x4082)   # "bluetooth:v05A7p4082d0000"
 # Check support status
 pybmap.is_supported(0x4082)  # True — has tested config
 pybmap.is_supported(0x4075)  # True — QuietComfort Headphones (prince)
-pybmap.is_supported(0x4039)  # False — QC45, recognized but untested
-pybmap.supported_devices()   # [wolfcastle, baywolf, edith, prince, wolverine]
+pybmap.is_supported(0x4039)  # True — QC45 uses an inferred config
+pybmap.supported_devices()   # eight devices; see docs/architecture.md
 pybmap.known_devices()       # full catalog
 ```
 
@@ -241,7 +246,7 @@ Full protocol reference: **[NOTES.md](NOTES.md)** and
 ```bash
 make test                       # All tests (121 Python, 63 Rust, 54 C++)
 make artifacts                  # Build + strip + SHA256SUMS in dist/
-make release VERSION=v0.2.0     # Test → build → gh release create
+make release VERSION=v0.4.0     # Test → build → gh release create
 make clean                      # Remove all build artifacts
 ```
 

--- a/cpp/src/bmap.h
+++ b/cpp/src/bmap.h
@@ -19,6 +19,16 @@ inline constexpr uint8_t FALLBACK_CHANNELS[] = {2, 8, 9};
 
 namespace detail {
 
+inline void validate_device_override(
+    const std::string& mac_override,
+    const std::string& device_type_override)
+{
+    if (!mac_override.empty() && device_type_override.empty()) {
+        throw std::invalid_argument(
+            "device_type is required when mac is specified");
+    }
+}
+
 inline void send_init(Transport& transport, const DeviceConfig& config) {
     if (config.init_packet) {
         auto pkt = bmap_packet(config.init_packet->fblock,
@@ -81,11 +91,12 @@ inline std::unique_ptr<RfcommTransport> open_transport(const std::string& mac,
 
 } // namespace detail
 
-/// Connect to a BMAP device, auto-detecting if mac/device_type are empty.
+/// Connect to a BMAP device. Device type is resolved only during MAC discovery.
 inline std::unique_ptr<BmapConnection> connect(
     const std::string& mac_override = "",
     const std::string& device_type_override = "")
 {
+    detail::validate_device_override(mac_override, device_type_override);
     std::string mac = mac_override;
     std::string device_type = device_type_override;
 
@@ -99,9 +110,6 @@ inline std::unique_ptr<BmapConnection> connect(
         if (device_type.empty()) {
             device_type = detected->second;
         }
-    }
-    if (device_type.empty()) {
-        device_type = "qc_ultra2";
     }
 
     auto config = get_device(device_type);

--- a/cpp/src/catalog.h
+++ b/cpp/src/catalog.h
@@ -53,7 +53,7 @@ inline const std::vector<BoseDevice>& catalog() {
         {0x404C, "celine_ii",  "Frames (2nd Gen)",                        Category::Earbuds, nullptr},
         {0x4060, "olivia",     "Frames Tempo",                            Category::Earbuds, nullptr},
         {0x4061, "vedder",     "Frames",                                  Category::Earbuds, nullptr},
-        {0x4062, "edith",      "QuietComfort Ultra Earbuds (2nd Gen)",    Category::Earbuds, "qc_ultra2"},
+        {0x4062, "edith",      "QuietComfort Ultra Earbuds (2nd Gen)",    Category::Earbuds, "qc_ultra2_earbuds"},
         {0x4064, "smalls",     "QuietComfort Earbuds II",                 Category::Earbuds, nullptr},
         {0x4068, "serena",     "Ultra Open Earbuds",                      Category::Earbuds, "ultra_open"},
         {0x4072, "scotty",     "QuietComfort Ultra Earbuds",              Category::Earbuds, nullptr},

--- a/cpp/src/connection.h
+++ b/cpp/src/connection.h
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <array>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -25,7 +26,28 @@ public:
 
     // ── Read Operations ─────────────────────────────────────────────────────
 
-    uint8_t battery()                     { return parse_battery(get(require(config_.battery, "battery"))); }
+    uint8_t battery() {
+        return battery_status().aggregate;
+    }
+    BatteryStatus battery_status() {
+        auto payload = get(require(config_.battery, "battery"));
+        if (config_.battery_aggregate_id) {
+            auto readings = parse_battery_readings(payload);
+            for (const auto& reading : readings) {
+                if (reading.component_id == *config_.battery_aggregate_id)
+                    return {reading.level, std::move(readings)};
+            }
+            throw std::runtime_error(
+                "Battery response missing aggregate component " +
+                std::to_string(*config_.battery_aggregate_id));
+        }
+        if (payload.empty())
+            throw std::runtime_error("Empty battery response");
+        return {parse_battery(payload), {}};
+    }
+    std::vector<BatteryReading> battery_readings() {
+        return battery_status().readings;
+    }
     std::string firmware()                { return parse_firmware(get(require(config_.firmware, "firmware"))); }
     std::string name()                    { return parse_product_name(get(require(config_.product_name, "product_name"))); }
     std::pair<uint8_t, uint8_t> cnc()     { return parse_cnc(get(require(config_.cnc, "cnc"))); }
@@ -90,9 +112,11 @@ public:
             [&]{ return cnc(); }, {0, 10});
         auto [prom_on, prom_lang] = safe_call<std::pair<bool,std::string>>(
             [&]{ return prompts(); }, {false, ""});
+        auto battery_state = battery_status();
 
         DeviceStatus s;
-        s.battery = battery();
+        s.battery = battery_state.aggregate;
+        s.battery_readings = std::move(battery_state.readings);
         s.mode = mode_name;
         s.mode_idx = idx;
         s.cnc_level = cnc_cur;
@@ -293,7 +317,7 @@ private:
         auto pkt = bmap_packet(addr.fblock, addr.func, Operator::Get);
         auto data = transport_->send_recv(pkt);
         auto resp = parse_response(data);
-        if (!resp) throw std::runtime_error("Empty response");
+        if (!resp) throw std::runtime_error("Invalid or empty response");
         check_error(*resp);
         return resp->payload;
     }

--- a/cpp/src/device.h
+++ b/cpp/src/device.h
@@ -6,7 +6,9 @@
 #include <cstdint>
 #include <functional>
 #include <optional>
+#include <stdexcept>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "protocol.h"
@@ -59,6 +61,16 @@ struct ButtonMapping {
     std::string action_name;
 };
 
+struct BatteryReading {
+    uint8_t component_id;
+    uint8_t level;
+};
+
+struct BatteryStatus {
+    uint8_t aggregate;
+    std::vector<BatteryReading> readings;
+};
+
 struct AudioSource {
     std::string source_type;
     std::string source_mac; // empty if not bluetooth
@@ -66,6 +78,7 @@ struct AudioSource {
 
 struct DeviceStatus {
     uint8_t battery;
+    std::vector<BatteryReading> battery_readings;
     std::string mode;
     uint8_t mode_idx;
     uint8_t cnc_level;
@@ -91,6 +104,10 @@ struct DeviceConfig {
     /// Init packet required before device responds (QC35 needs GET [0.1]).
     std::optional<Addr> init_packet;
     std::optional<Addr> battery;
+    /// Component IDs and display labels for multi-cell battery responses.
+    std::vector<std::pair<uint8_t, std::string>> battery_components;
+    /// Component ID used for the generic aggregate battery value.
+    std::optional<uint8_t> battery_aggregate_id;
     std::optional<Addr> firmware;
     std::optional<Addr> product_name;
     std::optional<Addr> voice_prompts;
@@ -126,6 +143,26 @@ struct DeviceConfig {
 
 inline uint8_t parse_battery(const std::vector<uint8_t>& p) {
     return p.empty() ? 0 : p[0];
+}
+
+/// Parse four-byte component battery records from [2.2].
+inline std::vector<BatteryReading> parse_battery_readings(const std::vector<uint8_t>& p) {
+    if (p.size() % 4 != 0) {
+        throw std::invalid_argument("Malformed battery response");
+    }
+    std::vector<BatteryReading> readings;
+    std::vector<uint8_t> seen_components;
+    for (size_t i = 0; i + 3 < p.size(); i += 4) {
+        for (auto component_id : seen_components) {
+            if (component_id == p[i + 3]) {
+                throw std::invalid_argument(
+                    "Duplicate battery component " + std::to_string(p[i + 3]));
+            }
+        }
+        seen_components.push_back(p[i + 3]);
+        if (p[i] <= 100) readings.push_back({p[i + 3], p[i]});
+    }
+    return readings;
 }
 
 inline std::string parse_firmware(const std::vector<uint8_t>& p) {

--- a/cpp/src/devices.h
+++ b/cpp/src/devices.h
@@ -41,6 +41,16 @@ inline DeviceConfig qc_ultra2() {
     return c;
 }
 
+/// Bose QuietComfort Ultra Earbuds 2 -- edith, product ID 0x4062.
+/// Shares the QC Ultra 2 protocol layout and reports separate battery cells.
+inline DeviceConfig qc_ultra2_earbuds() {
+    auto c = qc_ultra2();
+    c.info = {"Bose QuietComfort Ultra Earbuds (2nd Gen)", "edith", "OTG-QCC-384"};
+    c.battery_components = {{1, "Right"}, {2, "Left"}, {3, "Case"}};
+    c.battery_aggregate_id = 4;
+    return c;
+}
+
 /// Bose QuietComfort Headphones -- prince, product ID 0x4075.
 /// Verified against firmware 1.0.6-80+f5f219b. RFCOMM channel 8.
 inline DeviceConfig qc_prince() {
@@ -187,6 +197,7 @@ inline DeviceConfig ultra_open() {
 
 inline std::optional<DeviceConfig> get_device(const std::string& name) {
     if (name == "qc_ultra2") return qc_ultra2();
+    if (name == "qc_ultra2_earbuds") return qc_ultra2_earbuds();
     if (name == "qc35") return qc35();
     if (name == "qc_prince") return qc_prince();
     if (name == "qc_earbuds") return qc_earbuds();

--- a/cpp/src/main.cpp
+++ b/cpp/src/main.cpp
@@ -1,6 +1,7 @@
 // bmapctl — Minimal CLI for controlling BMAP devices (C++ version).
 
 #include <cstdlib>
+#include <iomanip>
 #include <iostream>
 #include <string>
 
@@ -30,7 +31,8 @@ static void usage() {
               << "  off                 Power off\n\n"
               << "Environment:\n"
               << "  BMAP_MAC=XX:XX:XX:XX:XX:XX   Device MAC\n"
-              << "  BMAP_DEVICE=qc_ultra2|qc_prince|qc35   Device type\n";
+              << "  BMAP_DEVICE=qc_ultra2|qc_ultra2_earbuds|qc_prince|qc35|"
+                 "qc_earbuds|qc45|ultra_open\n";
 }
 
 static bool is_on(const std::string& s) {
@@ -63,6 +65,15 @@ int main(int argc, char** argv) {
             auto s = dev.status();
             std::cout << "  Model        " << dev.config().info.name << "\n";
             std::cout << "  Battery      " << (int)s.battery << "%\n";
+            for (const auto& [id, label] : dev.config().battery_components) {
+                for (const auto& reading : s.battery_readings) {
+                    if (id == reading.component_id) {
+                        std::cout << "  " << std::left << std::setw(12) << label
+                                  << std::right << (int)reading.level << "%\n";
+                        break;
+                    }
+                }
+            }
             if (!s.mode.empty())
                 std::cout << "  Mode         " << s.mode << "\n";
             if (dev.has_feature("anr")) {

--- a/cpp/src/protocol.h
+++ b/cpp/src/protocol.h
@@ -90,13 +90,15 @@ inline std::vector<uint8_t> bmap_packet(uint8_t fblock, uint8_t func,
 
 inline std::optional<BmapResponse> parse_response(const std::vector<uint8_t>& data) {
     if (data.size() < 4) return std::nullopt;
+    auto raw_op = data[2] & 0x0F;
+    if (raw_op > static_cast<uint8_t>(Operator::Processing)) return std::nullopt;
     BmapResponse resp;
     resp.fblock = data[0];
     resp.func = data[1];
-    resp.op = static_cast<Operator>(data[2] & 0x0F);
+    resp.op = static_cast<Operator>(raw_op);
     uint8_t length = data[3];
-    size_t end = std::min<size_t>(4 + length, data.size());
-    resp.payload.assign(data.begin() + 4, data.begin() + end);
+    if (data.size() < 4 + length) return std::nullopt;
+    resp.payload.assign(data.begin() + 4, data.begin() + 4 + length);
     return resp;
 }
 
@@ -107,7 +109,9 @@ inline std::vector<BmapResponse> parse_all_responses(const std::vector<uint8_t>&
         BmapResponse resp;
         resp.fblock = data[pos];
         resp.func = data[pos + 1];
-        resp.op = static_cast<Operator>(data[pos + 2] & 0x0F);
+        auto raw_op = data[pos + 2] & 0x0F;
+        if (raw_op > static_cast<uint8_t>(Operator::Processing)) break;
+        resp.op = static_cast<Operator>(raw_op);
         uint8_t length = data[pos + 3];
         if (pos + 4 + length > data.size()) break;
         resp.payload.assign(data.begin() + pos + 4, data.begin() + pos + 4 + length);

--- a/cpp/tests/test_catalog.cpp
+++ b/cpp/tests/test_catalog.cpp
@@ -32,7 +32,7 @@ TEST(catalog_lookup_qc_ultra2_earbuds) {
     ASSERT_TRUE(dev != nullptr);
     ASSERT_EQ(std::string(dev->codename), std::string("edith"));
     ASSERT_TRUE(dev->config != nullptr);
-    ASSERT_EQ(std::string(dev->config), std::string("qc_ultra2"));
+    ASSERT_EQ(std::string(dev->config), std::string("qc_ultra2_earbuds"));
 }
 
 TEST(catalog_lookup_qc_prince) {

--- a/cpp/tests/test_connection.cpp
+++ b/cpp/tests/test_connection.cpp
@@ -7,6 +7,7 @@
 
 #include "../src/connection.h"
 #include "../src/devices.h"
+#include "../src/bmap.h"
 
 using namespace bmap;
 
@@ -52,6 +53,91 @@ static std::unique_ptr<BmapConnection> mock_qc_ultra2() {
 }
 
 TEST(battery) { ASSERT_EQ(mock_qc_ultra2()->battery(), 80); }
+
+TEST(battery_empty_response) {
+    auto raw = new MockTransport();
+    raw->add(2, 2, 0x03, {});
+    BmapConnection dev(std::unique_ptr<Transport>(raw), qc_ultra2());
+    bool threw = false;
+    try { dev.battery(); }
+    catch (const std::runtime_error& error) {
+        threw = std::string(error.what()).find("Empty battery response") != std::string::npos;
+    }
+    ASSERT_TRUE(threw);
+}
+
+TEST(battery_invalid_response) {
+    auto raw = new MockTransport();
+    raw->responses[{2, 2}] = {2, 2, 0x08, 0};
+    BmapConnection dev(std::unique_ptr<Transport>(raw), qc_ultra2());
+    bool threw = false;
+    try { dev.battery(); }
+    catch (const std::runtime_error& error) {
+        threw = std::string(error.what()).find("Invalid or empty response") != std::string::npos;
+    }
+    ASSERT_TRUE(threw);
+}
+
+TEST(battery_readings) {
+    auto raw = new MockTransport();
+    raw->add(2, 2, 0x03, {
+        0x50,0xff,0xff,0x03, 0x3c,0xff,0xff,0x01,
+        0x3c,0xff,0xff,0x02, 0x46,0xff,0xff,0x04,
+    });
+    BmapConnection dev(std::unique_ptr<Transport>(raw), qc_ultra2_earbuds());
+    auto battery = dev.battery_status();
+    ASSERT_EQ(battery.readings.size(), 4u);
+    ASSERT_EQ(battery.readings[0].component_id, 3);
+    ASSERT_EQ(battery.readings[0].level, 80);
+    ASSERT_EQ(battery.readings[3].component_id, 4);
+    ASSERT_EQ(dev.config().battery_components.size(), 3u);
+    ASSERT_EQ(battery.aggregate, 70);
+    ASSERT_EQ(raw->sent.size(), 1u);
+}
+
+TEST(battery_missing_aggregate_component) {
+    auto raw = new MockTransport();
+    raw->add(2, 2, 0x03, {
+        0x3c,0xff,0xff,0x01, 0x3c,0xff,0xff,0x02,
+        0x50,0xff,0xff,0x03,
+    });
+    BmapConnection dev(std::unique_ptr<Transport>(raw), qc_ultra2_earbuds());
+    bool threw = false;
+    try { dev.battery(); }
+    catch (const std::runtime_error& error) {
+        threw = std::string(error.what()).find("aggregate component 4") != std::string::npos;
+    }
+    ASSERT_TRUE(threw);
+}
+
+TEST(status_uses_one_battery_response) {
+    auto raw = new MockTransport();
+    raw->add(2, 2, 0x03, {
+        0x50,0xff,0xff,0x03, 0x3c,0xff,0xff,0x01,
+        0x46,0xff,0xff,0x04, 0x3c,0xff,0xff,0x02,
+    });
+    BmapConnection dev(std::unique_ptr<Transport>(raw), qc_ultra2_earbuds());
+    auto status = dev.status();
+    ASSERT_EQ(status.battery, 70);
+    ASSERT_EQ(status.battery_readings.size(), 4u);
+    size_t battery_requests = 0;
+    for (const auto& packet : raw->sent) {
+        if (packet.size() >= 2 && packet[0] == 2 && packet[1] == 2) battery_requests++;
+    }
+    ASSERT_EQ(battery_requests, 1u);
+}
+
+TEST(qc_ultra2_earbuds_config) {
+    auto config = qc_ultra2_earbuds();
+    ASSERT_EQ(config.info.codename, "edith");
+    ASSERT_EQ(config.info.name, "Bose QuietComfort Ultra Earbuds (2nd Gen)");
+    ASSERT_EQ(config.battery_components.size(), 3u);
+    ASSERT_EQ(config.battery_components[0].second, "Right");
+    ASSERT_EQ(config.battery_components[1].second, "Left");
+    ASSERT_EQ(config.battery_components[2].second, "Case");
+    ASSERT_EQ(*config.battery_aggregate_id, 4);
+    ASSERT_EQ(config.preset_modes.size(), 4u);
+}
 TEST(firmware) { ASSERT_EQ(mock_qc_ultra2()->firmware(), "8.2.20+g34cf029"); }
 TEST(device_name) { ASSERT_EQ(mock_qc_ultra2()->name(), "Fargo"); }
 
@@ -92,6 +178,15 @@ TEST(status_full) {
 TEST(has_feature_battery) { ASSERT_TRUE(mock_qc_ultra2()->has_feature("battery")); }
 TEST(has_feature_eq) { ASSERT_TRUE(mock_qc_ultra2()->has_feature("eq")); }
 TEST(has_feature_missing) { ASSERT_FALSE(mock_qc_ultra2()->has_feature("nonexistent")); }
+
+TEST(explicit_mac_requires_device_type) {
+    bool threw = false;
+    try { bmap::detail::validate_device_override("00:11:22:33:44:55", ""); }
+    catch (const std::invalid_argument& error) {
+        threw = std::string(error.what()).find("device_type is required") != std::string::npos;
+    }
+    ASSERT_TRUE(threw);
+}
 
 TEST(qc35_no_eq) {
     auto t = std::make_unique<MockTransport>();

--- a/cpp/tests/test_parsers.cpp
+++ b/cpp/tests/test_parsers.cpp
@@ -1,8 +1,28 @@
 // Tests for shared device parsers using real captured data.
 #include "test_common.h"
+#include <cctype>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
 #include "../src/device.h"
 
 using namespace bmap;
+
+static std::vector<uint8_t> decode_hex_fixture(const std::string& relative_path) {
+    auto path = std::filesystem::path(__FILE__).parent_path() / relative_path;
+    std::ifstream input(path);
+    if (!input) throw std::runtime_error("Could not open fixture: " + path.string());
+    std::string hex((std::istreambuf_iterator<char>(input)), {});
+    hex.erase(std::remove_if(hex.begin(), hex.end(), [](unsigned char c) {
+        return std::isspace(c);
+    }), hex.end());
+    if (hex.size() % 2 != 0) throw std::runtime_error("Fixture contains incomplete hex byte");
+    std::vector<uint8_t> bytes;
+    for (size_t i = 0; i < hex.size(); i += 2) {
+        bytes.push_back(static_cast<uint8_t>(std::stoul(hex.substr(i, 2), nullptr, 16)));
+    }
+    return bytes;
+}
 
 TEST(parse_battery_from_capture) {
     ASSERT_EQ(parse_battery({0x50, 0xff, 0xff, 0x00}), 0x50);
@@ -10,6 +30,34 @@ TEST(parse_battery_from_capture) {
 
 TEST(parse_battery_empty) {
     ASSERT_EQ(parse_battery({}), 0);
+}
+
+TEST(parse_battery_readings) {
+    auto readings = parse_battery_readings(decode_hex_fixture(
+        "../../fixtures/packets/qc-ultra2-earbuds/battery-status.hex"));
+    ASSERT_EQ(readings.size(), 4u);
+    ASSERT_EQ(readings[0].component_id, 1);
+    ASSERT_EQ(readings[0].level, 60);
+    ASSERT_EQ(readings[3].component_id, 3);
+    ASSERT_EQ(readings[3].level, 80);
+    auto shuffled = parse_battery_readings({
+        0x50,0xff,0xff,0x03, 0x46,0xff,0xff,0x04,
+        0x32,0xff,0xff,0x09, 0x3c,0xff,0xff,0x01,
+        0x3c,0xff,0xff,0x02,
+    });
+    ASSERT_EQ(shuffled.size(), 5u);
+    ASSERT_EQ(shuffled[0].component_id, 3);
+    ASSERT_EQ(shuffled[1].component_id, 4);
+    ASSERT_EQ(shuffled[2].component_id, 9);
+    bool threw = false;
+    try { parse_battery_readings({0x50, 0xff}); }
+    catch (const std::invalid_argument&) { threw = true; }
+    ASSERT_TRUE(threw);
+    threw = false;
+    try { parse_battery_readings({
+        0x3c,0xff,0xff,0x01, 0x50,0xff,0xff,0x01}); }
+    catch (const std::invalid_argument&) { threw = true; }
+    ASSERT_TRUE(threw);
 }
 
 TEST(parse_firmware_from_capture) {

--- a/cpp/tests/test_protocol.cpp
+++ b/cpp/tests/test_protocol.cpp
@@ -34,6 +34,8 @@ TEST(parse_response_basic) {
 TEST(parse_response_too_short) {
     auto resp = parse_response({1, 2});
     ASSERT_FALSE(resp.has_value());
+    ASSERT_FALSE(parse_response({2, 2, 0x03, 4, 80, 0xff}).has_value());
+    ASSERT_FALSE(parse_response({2, 2, 0x08, 0}).has_value());
 }
 
 TEST(parse_all_responses_two) {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -129,6 +129,7 @@ graph LR
         FEAT[Feature Map<br/>name → addr + parser + builder]
         MODES[Preset Modes<br/>name → index]
         SLOTS[Editable Slots<br/>profile indices]
+        CELLS[Battery Metadata<br/>component ID → label<br/>aggregate component ID]
     end
 ```
 
@@ -143,6 +144,11 @@ Each feature entry maps a name to its protocol address and codec functions:
 ```
 
 **Device quirks are expressed as config differences, not code branches:**
+
+Multi-component battery devices declare display labels and an aggregate
+component ID in config. For `edith`, IDs 1/2/3 are Right/Left/Case and ID 4
+is the combined earbud level. Unknown IDs are preserved in the snapshot but
+only configured components are rendered.
 
 | Property | QC Ultra 2 | QuietComfort Headphones (`prince`) | QC35 |
 |----------|-----------|-------------------------------------|------|
@@ -185,8 +191,13 @@ sequenceDiagram
 
 **Read pattern** (GET):
 ```
-battery()  →  _get("battery")  →  lookup addr  →  send GET  →  parse response  →  apply parser
+battery_status()  →  one GET  →  aggregate level + component ID/level pairs
+battery() / status()  →  reuse the parsed battery status
 ```
+
+`BatteryStatus` keeps the aggregate and all component readings from that one
+response. `DeviceStatus.battery_readings` carries the same snapshot to CLIs,
+which render known components in config order rather than packet order.
 
 **Write pattern** (SETGET):
 ```
@@ -207,6 +218,7 @@ feature map, not inherited.
 **Parsers** decode response payloads:
 ```
 parse_battery([0x50, 0xff, 0xff, 0x00])  →  80
+parse_battery_readings([0x3c,0xff,0xff,0x01, ...])  →  [(component=1, level=60), ...]
 parse_cnc([0x0b, 0x07, 0x03])            →  (current=7, max=10)
 parse_anr([0x01, 0x0b])                  →  "high"
 parse_buttons([0x10, 0x04, 0x01, 0x07])  →  ButtonMapping{Action, single_press, VPA}
@@ -258,6 +270,8 @@ sequenceDiagram
 3. Modalias product ID maps to a known device type
 
 Connected devices are preferred over paired-but-disconnected.
+When a caller supplies a MAC explicitly, it must also supply the device config
+key; the type can only be detected while discovering the MAC.
 
 ## Error Handling
 
@@ -317,7 +331,7 @@ graph TD
     CAT[Device Catalog<br/>known BMAP devices] --> SUP[Supported<br/>config ≠ None]
     CAT --> UNSUP[Recognized but Unsupported<br/>config = None]
     SUP --> DISC[Discovery<br/>PID → config lookup]
-    SUP --> CFG[Device Configs<br/>qc_ultra2, qc_prince, qc35]
+    SUP --> CFG[Device Configs<br/>qc_ultra2, qc_ultra2_earbuds, qc_prince, qc35]
     DISC --> CONN[connect&#40;&#41;]
     CFG --> CONN
 
@@ -343,9 +357,10 @@ Each catalog entry carries:
 
 ```
 lookup_device(0x4082)    → BoseDevice{wolverine, "QuietComfort Ultra Headphones (2nd Gen)", config="qc_ultra2"}
+lookup_device(0x4062)    → BoseDevice{edith, "QuietComfort Ultra Earbuds (2nd Gen)", config="qc_ultra2_earbuds"}
 lookup_device(0x4075)    → BoseDevice{prince, "QuietComfort Headphones", config="qc_prince"}
 is_supported(0x4024)     → False (NCH 700: recognized, no config yet)
-supported_devices()      → [wolfcastle, baywolf, edith, prince, wolverine]
+supported_devices()      → [wolfcastle, baywolf, duran, prince, wolverine, lando, edith, serena]
 known_devices()          → full catalog
 usb_ids(0x4082)          → (0x05A7, 0x4082)
 modalias(0x4082)         → "bluetooth:v05A7p4082d0000"
@@ -368,7 +383,7 @@ a default config since they don't have a tested implementation yet.
 |-----|----------|---------|--------|
 | `0x400C` | wolfcastle | QuietComfort 35 | `qc35` |
 | `0x4020` | baywolf | QuietComfort 35 II | `qc35` |
-| `0x4062` | edith | QuietComfort Ultra Earbuds (2nd Gen) | `qc_ultra2` |
+| `0x4062` | edith | QuietComfort Ultra Earbuds (2nd Gen) | `qc_ultra2_earbuds` |
 | `0x4075` | prince | QuietComfort Headphones | `qc_prince` |
 | `0x402F` | lando | QuietComfort Earbuds | `qc_earbuds` |
 | `0x4039` | duran | QuietComfort 45 | `qc45` (inferred, untested) |
@@ -414,6 +429,7 @@ pybmap/
 ├── protocol.py          # Packet codec (bmap_packet, parse_response)
 ├── transport.py         # RfcommTransport (AF_BLUETOOTH socket)
 ├── connection.py        # BmapConnection class
+├── cli.py               # bosectl command-line interface
 ├── discovery.py         # find_bmap_device() via bluetoothctl
 ├── constants.py         # Operators, error codes, button/action/language tables
 ├── types.py             # NamedTuples (BmapResponse, ModeConfig, ButtonMapping, etc.)
@@ -422,7 +438,11 @@ pybmap/
     ├── __init__.py      # Device registry (DEVICES dict, get_device())
     ├── parsers.py       # Shared parser/builder functions
     ├── qc_ultra2.py     # QC Ultra 2 config (module-level constants)
+    ├── qc_ultra2_earbuds.py # QC Ultra 2 Earbuds config (shared layout)
     ├── qc_prince.py     # QuietComfort Headphones / prince config
+    ├── qc45.py          # QC45 config
+    ├── qc_earbuds.py    # QuietComfort Earbuds config
+    ├── ultra_open.py    # Ultra Open Earbuds partial config
     └── qc35.py          # QC35 config (module-level constants)
 ```
 
@@ -459,7 +479,7 @@ rust/src/
 ├── connection.rs        # BmapConnection<T: Transport> generic struct
 ├── discovery.rs         # find_bmap_device() via bluetoothctl
 ├── device.rs            # DeviceConfig struct, all parsers/builders
-├── devices.rs           # qc_ultra2() / qc35() factory functions
+├── devices.rs           # qc_ultra2() / qc_ultra2_earbuds() / qc35()
 ├── error.rs             # BmapError enum, BmapResult type alias
 └── main.rs              # CLI binary (bmapctl)
 ```
@@ -514,7 +534,7 @@ cpp/src/
 ├── transport.cpp        # RfcommTransport (BlueZ sockets)
 ├── connection.h         # BmapConnection class (header-only)
 ├── device.h             # DeviceConfig, all parsers/builders (header-only)
-├── devices.h            # qc_ultra2() / qc35() inline functions
+├── devices.h            # qc_ultra2() / qc_ultra2_earbuds() / qc35()
 ├── discovery.h          # find_bmap_device() declaration
 ├── discovery.cpp        # Discovery implementation
 └── main.cpp             # CLI binary (bmapctl)

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -5,7 +5,8 @@ Shared across Python, Rust, and C++ test suites.
 
 ## Structure
 
-- `packets/<device>/` — Raw captured request/response pairs (JSON files from bmap-capture.py)
+- `packets/<device>/` — Raw captured request/response pairs and payloads
+  (`.json` snapshots or plain hexadecimal `.hex` files)
 - `expected/` — Expected parse results for unit tests (JSON)
 
 ## Packet format

--- a/fixtures/packets/qc-ultra2-earbuds/battery-status.hex
+++ b/fixtures/packets/qc-ultra2-earbuds/battery-status.hex
@@ -1,0 +1,1 @@
+3cffff013cffff023cffff0450ffff03

--- a/python/pybmap/__init__.py
+++ b/python/pybmap/__init__.py
@@ -27,11 +27,14 @@ from .errors import (
     BmapError, BmapConnectionError, BmapAuthError,
     BmapDeviceError, BmapTimeoutError, BmapNotFoundError,
 )
-from .types import DeviceStatus, ModeConfig, EqBand, ButtonMapping, BmapResponse
+from .types import (
+    BatteryReading, BatteryStatus, BmapResponse, ButtonMapping, DeviceStatus,
+    EqBand, ModeConfig,
+)
 from .protocol import bmap_packet, parse_response, parse_all_responses
 from .constants import OP_STATUS
 
-__version__ = "0.1.0"
+__version__ = "0.4.0"
 
 
 def connect(mac=None, device_type=None):
@@ -40,7 +43,7 @@ def connect(mac=None, device_type=None):
     Args:
         mac: Bluetooth MAC address. Auto-detected if None.
         device_type: Device type string (e.g. "qc_ultra2", "qc35").
-                     Defaults to "qc_ultra2" if not specified.
+                     Required when mac is specified; auto-detected otherwise.
 
     Returns:
         BmapConnection context manager.
@@ -49,6 +52,9 @@ def connect(mac=None, device_type=None):
         BmapNotFoundError: If no device is found.
         BmapConnectionError: If the connection fails.
     """
+    mac = mac or None
+    device_type = device_type or None
+
     if mac is None:
         detected_mac, detected_type = find_bmap_device()
         if detected_mac is None:
@@ -59,9 +65,8 @@ def connect(mac=None, device_type=None):
         mac = detected_mac
         if device_type is None:
             device_type = detected_type
-
-    if device_type is None:
-        device_type = "qc_ultra2"
+    elif device_type is None:
+        raise BmapError("device_type is required when mac is specified")
 
     device = get_device(device_type)
     channel = getattr(device, "RFCOMM_CHANNEL", 2)

--- a/python/pybmap/catalog.py
+++ b/python/pybmap/catalog.py
@@ -59,7 +59,7 @@ CATALOG = {
     0x404C: BoseDevice(0x404C, "celine_ii",  "Frames (2nd Gen)",                     "earbuds", None),
     0x4060: BoseDevice(0x4060, "olivia",     "Frames Tempo",                         "earbuds", None),
     0x4061: BoseDevice(0x4061, "vedder",     "Frames",                               "earbuds", None),
-    0x4062: BoseDevice(0x4062, "edith",      "QuietComfort Ultra Earbuds (2nd Gen)", "earbuds", "qc_ultra2"),
+    0x4062: BoseDevice(0x4062, "edith",      "QuietComfort Ultra Earbuds (2nd Gen)", "earbuds", "qc_ultra2_earbuds"),
     0x4064: BoseDevice(0x4064, "smalls",     "QuietComfort Earbuds II",              "earbuds", None),
     0x4068: BoseDevice(0x4068, "serena",     "Ultra Open Earbuds",                   "earbuds", "ultra_open"),
     0x4072: BoseDevice(0x4072, "scotty",     "QuietComfort Ultra Earbuds",           "earbuds", None),

--- a/python/pybmap/cli.py
+++ b/python/pybmap/cli.py
@@ -63,6 +63,13 @@ def cmd_status(dev):
     row("Model", dev.device_info.get("name", "Unknown"), C_MAGENTA)
     batt_color = C_GREEN if s.battery > 30 else C_YELLOW if s.battery > 10 else C_RED
     row("Battery", "%d%%" % s.battery, batt_color)
+    component_names = dev.battery_components
+    readings = {reading.component_id: reading.level for reading in s.battery_readings}
+    for component_id, label in component_names.items():
+        if component_id in readings:
+            level = readings[component_id]
+            color = C_GREEN if level > 30 else C_YELLOW if level > 10 else C_RED
+            row(label, "%d%%" % level, color)
     if s.mode:
         row("Mode", s.mode, C_CYAN)
 

--- a/python/pybmap/connection.py
+++ b/python/pybmap/connection.py
@@ -18,7 +18,8 @@ from .constants import (
 )
 from .protocol import bmap_packet, parse_response, parse_all_responses, fmt_response
 from .errors import BmapError, BmapAuthError, BmapDeviceError
-from .types import DeviceStatus, AudioSettings
+from .types import AudioSettings, BatteryStatus, DeviceStatus
+from .devices import parsers
 
 
 # The device name field is 32 bytes on every BMAP device seen so far.
@@ -53,20 +54,26 @@ class BmapConnection:
             )
         return features[name]
 
-    def _get(self, feature_name):
-        """Send a GET request and return the parsed payload."""
+    def _get_payload(self, feature_name):
+        """Send a GET request and return its raw payload."""
         feat = self._feature(feature_name)
         fblock, func = feat["addr"]
         resp = self._transport.send_recv(bmap_packet(fblock, func, OP_GET))
         parsed = parse_response(resp)
         if parsed is None:
-            return None
+            raise BmapDeviceError("Invalid or empty response")
         if parsed.op == OP_ERROR:
             self._raise_error(parsed)
+        return parsed.payload
+
+    def _get(self, feature_name):
+        """Send a GET request and return its parsed payload."""
+        feat = self._feature(feature_name)
+        payload = self._get_payload(feature_name)
         parser = feat.get("parser")
         if parser:
-            return parser(parsed.payload)
-        return parsed.payload
+            return parser(payload)
+        return payload
 
     def _setget(self, feature_name, payload):
         """Send a SETGET request and return the parsed response."""
@@ -126,7 +133,38 @@ class BmapConnection:
 
     def battery(self):
         """Battery percentage (int)."""
-        return self._get("battery")
+        return self.battery_status().aggregate
+
+    def battery_status(self):
+        """Aggregate and component levels from one battery response."""
+        feature = self._feature("battery")
+        payload = self._get_payload("battery")
+
+        aggregate_id = self.battery_aggregate_id
+        if aggregate_id is None:
+            parser = feature.get("parser", parsers.parse_battery)
+            aggregate = parser(payload)
+            if aggregate is None:
+                raise BmapDeviceError("Empty battery response")
+            return BatteryStatus(aggregate=aggregate, readings=[])
+
+        try:
+            readings = parsers.parse_battery_readings(payload)
+        except ValueError as error:
+            raise BmapDeviceError(str(error)) from error
+        aggregate = next(
+            (reading.level for reading in readings
+             if reading.component_id == aggregate_id),
+            None,
+        )
+        if aggregate is None:
+            raise BmapDeviceError(
+                "Battery response missing aggregate component %d" % aggregate_id)
+        return BatteryStatus(aggregate=aggregate, readings=readings)
+
+    def battery_readings(self):
+        """Component battery readings, when the device reports multiple cells."""
+        return self.battery_status().readings
 
     def firmware(self):
         """Firmware version string."""
@@ -261,9 +299,11 @@ class BmapConnection:
         current_name = self._mode_name_from_idx(current_idx) if current_idx is not None else ""
         cnc_cur, cnc_max = self._safe_read(self.cnc, (0, 10))
         prompts_on, prompts_lang = self._safe_read(self.prompts, (False, ""))
+        battery = self.battery_status()
 
         return DeviceStatus(
-            battery=self.battery(),
+            battery=battery.aggregate,
+            battery_readings=battery.readings,
             mode=current_name,
             mode_idx=current_idx,
             cnc_level=cnc_cur, cnc_max=cnc_max,
@@ -551,6 +591,16 @@ class BmapConnection:
     def device_info(self):
         """Device identification dict."""
         return self._device.DEVICE_INFO
+
+    @property
+    def battery_components(self):
+        """Known component ID to label mappings for battery readings."""
+        return getattr(self._device, "BATTERY_COMPONENTS", {})
+
+    @property
+    def battery_aggregate_id(self):
+        """Component ID used for the generic battery level, when applicable."""
+        return getattr(self._device, "BATTERY_AGGREGATE_ID", None)
 
     @property
     def preset_modes(self):

--- a/python/pybmap/devices/__init__.py
+++ b/python/pybmap/devices/__init__.py
@@ -1,6 +1,7 @@
 """Device registry for BMAP-capable devices."""
 
 from . import qc_ultra2
+from . import qc_ultra2_earbuds
 from . import qc35
 from . import qc_prince
 from . import qc_earbuds
@@ -10,6 +11,7 @@ from . import ultra_open
 # Registry of supported devices keyed by type string.
 DEVICES = {
     "qc_ultra2": qc_ultra2,
+    "qc_ultra2_earbuds": qc_ultra2_earbuds,
     "qc35": qc35,
     "qc_prince": qc_prince,
     "qc_earbuds": qc_earbuds,
@@ -20,6 +22,7 @@ DEVICES = {
 # Product ID -> device type (for auto-detection after connecting).
 PRODUCT_IDS = {
     0x4082: "qc_ultra2",
+    0x4062: "qc_ultra2_earbuds",
     0x4075: "qc_prince",
     0x402F: "qc_earbuds",
     0x4039: "qc45",

--- a/python/pybmap/devices/parsers.py
+++ b/python/pybmap/devices/parsers.py
@@ -23,6 +23,30 @@ def parse_battery(payload):
     return None
 
 
+def parse_battery_readings(payload):
+    """Parse four-byte component battery records.
+
+    Earbud responses observed on BMAP [2.2] use the layout
+    ``[level, reserved, reserved, component_id]``.
+    """
+    from ..types import BatteryReading
+
+    if len(payload) % 4:
+        raise ValueError("Malformed battery response")
+
+    readings = []
+    seen_components = set()
+    for i in range(0, len(payload) - 3, 4):
+        level = payload[i]
+        component_id = payload[i + 3]
+        if component_id in seen_components:
+            raise ValueError("Duplicate battery component %d" % component_id)
+        seen_components.add(component_id)
+        if level <= 100:
+            readings.append(BatteryReading(component_id, level))
+    return readings
+
+
 def parse_firmware(payload):
     """Parse firmware version string."""
     return payload.decode("ascii", errors="replace")

--- a/python/pybmap/devices/qc_ultra2_earbuds.py
+++ b/python/pybmap/devices/qc_ultra2_earbuds.py
@@ -1,0 +1,34 @@
+"""Bose QuietComfort Ultra Earbuds (2nd Gen) device configuration.
+
+The earbuds use the same tested BMAP feature layout as QC Ultra 2 headphones,
+but report separate battery records for the left bud, right bud, and case.
+"""
+
+from .qc_ultra2 import (
+    DEVICE_INFO as _HEADPHONE_INFO,
+    EDITABLE_SLOTS,
+    FEATURES as _HEADPHONE_FEATURES,
+    MODE_BY_IDX,
+    PRESET_MODES,
+    RFCOMM_CHANNEL,
+    STATUS_OFFSETS,
+)
+
+
+DEVICE_INFO = dict(_HEADPHONE_INFO)
+DEVICE_INFO.update({
+    "name": "Bose QuietComfort Ultra Earbuds (2nd Gen)",
+    "codename": "edith",
+    "product_id": 0x4062,
+    "category": "earbuds",
+})
+
+# Keep the shared feature layout. Case charging is intentionally not exposed:
+# BMAP [2.5] changes with earbud seating, but stayed the same across observed
+# charger transitions, so it is not a reliable charging boolean.
+FEATURES = dict(_HEADPHONE_FEATURES)
+
+# Product-specific IDs: 1=right, 2=left, 3=case, 4=combined buds.
+# ID 4 is the combined earbud reading and is intentionally not displayed.
+BATTERY_COMPONENTS = {1: "Right", 2: "Left", 3: "Case"}
+BATTERY_AGGREGATE_ID = 4

--- a/python/pybmap/protocol.py
+++ b/python/pybmap/protocol.py
@@ -39,7 +39,11 @@ def parse_response(data):
     fblock = data[0]
     func = data[1]
     op = data[2] & 0x0F
+    if op not in OP_NAMES:
+        return None
     length = data[3]
+    if len(data) < 4 + length:
+        return None
     payload = data[4:4 + length]
     return BmapResponse(fblock, func, op, payload)
 
@@ -60,6 +64,8 @@ def parse_all_responses(data):
         fblock = data[pos]
         func = data[pos + 1]
         op = data[pos + 2] & 0x0F
+        if op not in OP_NAMES:
+            break
         length = data[pos + 3]
         if pos + 4 + length > len(data):
             break  # Truncated packet

--- a/python/pybmap/types.py
+++ b/python/pybmap/types.py
@@ -25,6 +25,12 @@ ModeConfig = namedtuple("ModeConfig", [
 # A single EQ band reading.
 EqBand = namedtuple("EqBand", ["band_id", "name", "min_val", "max_val", "current"])
 
+# A single component battery reading from a multi-battery device.
+BatteryReading = namedtuple("BatteryReading", ["component_id", "level"])
+
+# Aggregate and component readings parsed from one battery response.
+BatteryStatus = namedtuple("BatteryStatus", ["aggregate", "readings"])
+
 # Complete device status snapshot.
 DeviceStatus = namedtuple("DeviceStatus", [
     "battery",
@@ -41,7 +47,10 @@ DeviceStatus = namedtuple("DeviceStatus", [
     "auto_answer",
     "prompts_enabled",
     "prompts_language",
+    "battery_readings",  # List of BatteryReading from the same response
 ])
+# Preserve positional construction of the pre-snapshot status shape.
+DeviceStatus.__new__.__defaults__ = ((),)
 
 # Current audio settings (CNC, spatial, wind, ANC) from [31.10].
 AudioSettings = namedtuple("AudioSettings", [

--- a/python/tests/test_catalog.py
+++ b/python/tests/test_catalog.py
@@ -28,7 +28,7 @@ class TestLookup:
     def test_qc_ultra2_earbuds(self):
         dev = lookup_device(0x4062)
         assert dev.codename == "edith"
-        assert dev.config == "qc_ultra2"
+        assert dev.config == "qc_ultra2_earbuds"
 
     def test_quietcomfort_headphones_prince(self):
         dev = lookup_device(0x4075)

--- a/python/tests/test_channel_probe.py
+++ b/python/tests/test_channel_probe.py
@@ -4,7 +4,7 @@ import pytest
 
 import pybmap
 from pybmap.constants import OP_STATUS, OP_PROCESSING, OP_ERROR
-from pybmap.errors import BmapConnectionError, BmapTimeoutError, BmapDeviceError
+from pybmap.errors import BmapConnectionError, BmapTimeoutError, BmapDeviceError, BmapError
 from pybmap.devices import qc_prince
 from tests.test_connection import MockTransport
 
@@ -93,6 +93,25 @@ def test_fallback_order_skips_duplicate_of_configured(patch_transport):
     with pytest.raises(BmapConnectionError):
         pybmap.connect(mac="00:11:22:33:44:55", device_type="qc_ultra2")
     assert f.attempts == [2, 8, 9]
+
+
+@pytest.mark.parametrize("device_type", [None, ""])
+def test_explicit_mac_requires_device_type(patch_transport, device_type):
+    f = patch_transport({2: "bmap"})
+    with pytest.raises(BmapError, match="device_type is required"):
+        pybmap.connect(mac="00:11:22:33:44:55", device_type=device_type)
+    assert f.attempts == []
+
+
+def test_empty_mac_uses_discovery(patch_transport, monkeypatch):
+    f = patch_transport({2: "bmap"})
+    monkeypatch.setattr(
+        pybmap, "find_bmap_device",
+        lambda: ("00:11:22:33:44:55", "qc_ultra2"),
+    )
+    dev = pybmap.connect(mac="")
+    dev.close()
+    assert f.attempts == [2]
 
 
 class TestModeSwitchAck:

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -1,0 +1,56 @@
+"""Tests for user-visible CLI output."""
+
+from pybmap.cli import cmd_status
+from pybmap.types import BatteryReading, DeviceStatus
+
+
+class StatusDevice:
+    device_info = {"name": "Bose QuietComfort Ultra Earbuds (2nd Gen)"}
+    battery_components = {1: "Right", 2: "Left", 3: "Case"}
+
+    def status(self):
+        return DeviceStatus(
+            battery=70,
+            battery_readings=[
+                BatteryReading(3, 80),
+                BatteryReading(4, 70),
+                BatteryReading(2, 60),
+                BatteryReading(1, 50),
+            ],
+            mode="quiet",
+            mode_idx=0,
+            cnc_level=0,
+            cnc_max=10,
+            eq=[],
+            name="edith",
+            firmware="1.0.0",
+            sidetone="off",
+            multipoint=False,
+            auto_pause=True,
+            auto_answer=False,
+            prompts_enabled=False,
+            prompts_language="US English",
+        )
+
+    def has_feature(self, _name):
+        return False
+
+
+def test_status_orders_known_components_and_hides_combined(capsys):
+    cmd_status(StatusDevice())
+    output = capsys.readouterr().out
+
+    assert output.index("Right") < output.index("Left") < output.index("Case")
+    assert "Right        50%" in output
+    assert "Left         60%" in output
+    assert "Case         80%" in output
+    assert "Combined" not in output
+
+
+def test_device_status_preserves_old_positional_shape():
+    status = DeviceStatus(
+        80, "quiet", 0, 7, 10, [], "Device", "1.0.0", "off",
+        False, True, False, True, "English",
+    )
+    assert status.mode == "quiet"
+    assert status.battery_readings == ()

--- a/python/tests/test_connection.py
+++ b/python/tests/test_connection.py
@@ -1,11 +1,13 @@
 """Tests for BmapConnection using a mock transport."""
 
+from types import SimpleNamespace
+
 import pytest
 from pybmap.connection import BmapConnection
 from pybmap.protocol import bmap_packet
 from pybmap.constants import OP_GET, OP_SETGET, OP_STATUS, OP_RESULT, OP_ERROR
 from pybmap.errors import BmapError, BmapAuthError, BmapDeviceError
-from pybmap.devices import qc_ultra2, qc_prince
+from pybmap.devices import qc_ultra2, qc_ultra2_earbuds, qc_prince
 
 
 class MockTransport:
@@ -57,6 +59,75 @@ def mock_dev():
 class TestReadOperations:
     def test_battery(self, mock_dev):
         assert mock_dev.battery() == 80
+
+    def test_battery_rejects_empty_response(self):
+        transport = MockTransport()
+        transport.add_response(2, 2, OP_STATUS, b"")
+        dev = BmapConnection(transport, qc_ultra2)
+        with pytest.raises(BmapDeviceError, match="Empty battery response"):
+            dev.battery()
+
+    @pytest.mark.parametrize("response", [
+        bytes([2, 2, OP_STATUS, 4, 80, 0xff]),
+        bytes([2, 2, 0x08, 0]),
+    ])
+    def test_battery_rejects_invalid_frame(self, response):
+        transport = MockTransport()
+        transport.responses[(2, 2)] = response
+        dev = BmapConnection(transport, qc_ultra2)
+        with pytest.raises(BmapDeviceError, match="Invalid or empty response"):
+            dev.battery()
+
+    def test_battery_uses_configured_parser(self):
+        transport = MockTransport()
+        transport.add_response(2, 2, OP_STATUS, bytes([80]))
+        device = SimpleNamespace(
+            DEVICE_INFO={"name": "Custom"},
+            FEATURES={
+                "battery": {
+                    "addr": (2, 2),
+                    "parser": lambda payload: payload[0] - 1,
+                },
+            },
+        )
+        assert BmapConnection(transport, device).battery() == 79
+
+    def test_battery_readings(self):
+        transport = MockTransport()
+        transport.add_response(2, 2, OP_STATUS,
+                               bytes.fromhex("50ffff033cffff013cffff0246ffff04"))
+        dev = BmapConnection(transport, qc_ultra2_earbuds)
+        readings = dev.battery_readings()
+        assert [(r.component_id, r.level) for r in readings] == [
+            (3, 80), (1, 60), (2, 60), (4, 70)
+        ]
+
+    def test_battery_uses_combined_earbud_record(self):
+        transport = MockTransport()
+        transport.add_response(2, 2, OP_STATUS,
+                               bytes.fromhex("46ffff0450ffff023cffff0140ffff03"))
+        dev = BmapConnection(transport, qc_ultra2_earbuds)
+        assert dev.battery() == 70
+
+    def test_battery_rejects_missing_aggregate_component(self):
+        transport = MockTransport()
+        transport.add_response(2, 2, OP_STATUS,
+                               bytes.fromhex("3cffff0150ffff0240ffff03"))
+        dev = BmapConnection(transport, qc_ultra2_earbuds)
+        with pytest.raises(BmapDeviceError, match="aggregate component 4"):
+            dev.battery()
+
+    def test_status_uses_one_battery_response(self):
+        transport = MockTransport()
+        transport.add_response(2, 2, OP_STATUS,
+                               bytes.fromhex("50ffff033cffff0146ffff043cffff02"))
+        dev = BmapConnection(transport, qc_ultra2_earbuds)
+        status = dev.status()
+        assert status.battery == 70
+        assert [(r.component_id, r.level) for r in status.battery_readings] == [
+            (3, 80), (1, 60), (4, 70), (2, 60)
+        ]
+        assert sum(packet[:2] == bytes([2, 2]) for packet in transport.sent) == 1
 
     def test_firmware(self, mock_dev):
         assert mock_dev.firmware() == "8.2.20+g34cf029"
@@ -111,6 +182,7 @@ class TestStatus:
     def test_returns_full_status(self, mock_dev):
         s = mock_dev.status()
         assert s.battery == 80
+        assert s.battery_readings == []
         assert s.mode == "quiet"
         assert s.cnc_level == 7
         assert s.cnc_max == 10

--- a/python/tests/test_device_parsers.py
+++ b/python/tests/test_device_parsers.py
@@ -1,7 +1,12 @@
 """Tests for device-specific parsers using real captured data."""
 
+from pathlib import Path
+
+import pytest
+
 from pybmap.devices.parsers import (
     parse_battery, parse_firmware, parse_product_name, parse_cnc,
+    parse_battery_readings,
     parse_eq, parse_buttons, parse_multipoint, parse_bool,
     parse_sidetone, parse_voice_prompts,
     parse_mode_config_48, parse_mode_config_47,
@@ -10,6 +15,11 @@ from pybmap.devices.parsers import (
     build_buttons,
 )
 from pybmap.types import ModeConfig, EqBand, ButtonMapping
+
+
+EDITH_BATTERY_CAPTURE = Path(
+    __file__
+).parents[2] / "fixtures/packets/qc-ultra2-earbuds/battery-status.hex"
 
 
 # ── Test data from real QC Ultra 2 captures ──────────────────────────────────
@@ -23,6 +33,30 @@ class TestParseBattery:
 
     def test_empty(self):
         assert parse_battery(bytes()) is None
+
+
+class TestParseBatteryReadings:
+    def test_multi_component_capture(self):
+        payload = bytes.fromhex(EDITH_BATTERY_CAPTURE.read_text().strip())
+        readings = parse_battery_readings(payload)
+        assert [(r.component_id, r.level) for r in readings] == [
+            (1, 60), (2, 60), (4, 60), (3, 80)
+        ]
+
+    def test_rejects_incomplete_record(self):
+        with pytest.raises(ValueError, match="Malformed battery response"):
+            parse_battery_readings(bytes.fromhex("50ffff"))
+
+    def test_rejects_duplicate_component(self):
+        with pytest.raises(ValueError, match="Duplicate battery component 1"):
+            parse_battery_readings(bytes.fromhex("3cffff0150ffff01"))
+
+    def test_preserves_shuffled_component_ids(self):
+        payload = bytes.fromhex("50ffff0332ffff0946ffff043cffff013cffff02")
+        readings = parse_battery_readings(payload)
+        assert [(r.component_id, r.level) for r in readings] == [
+            (3, 80), (9, 50), (4, 70), (1, 60), (2, 60)
+        ]
 
 
 class TestParseFirmware:

--- a/python/tests/test_protocol.py
+++ b/python/tests/test_protocol.py
@@ -60,6 +60,12 @@ class TestParseResponse:
         assert parse_response(bytes([1, 2, 3])) is None
         assert parse_response(bytes()) is None
 
+    def test_truncated_payload(self):
+        assert parse_response(bytes([2, 2, OP_STATUS, 4, 80, 0xff])) is None
+
+    def test_invalid_operator(self):
+        assert parse_response(bytes([2, 2, 0x08, 0])) is None
+
     def test_status_with_payload(self):
         payload = bytes([0x50, 0xff, 0xff, 0x00])  # Battery STATUS
         data = bytes([2, 2, 0x03, len(payload)]) + payload

--- a/python/tests/test_qc_ultra2.py
+++ b/python/tests/test_qc_ultra2.py
@@ -1,11 +1,14 @@
 """Tests for QC Ultra 2 device configuration."""
 
-from pybmap.devices import qc_ultra2, qc_prince, DEVICES, get_device
+from pybmap.devices import qc_ultra2, qc_ultra2_earbuds, qc_prince, DEVICES, get_device
 
 
 class TestDeviceRegistry:
     def test_qc_ultra2_registered(self):
         assert "qc_ultra2" in DEVICES
+
+    def test_qc_ultra2_earbuds_registered(self):
+        assert "qc_ultra2_earbuds" in DEVICES
 
     def test_qc35_registered(self):
         assert "qc35" in DEVICES
@@ -30,6 +33,10 @@ class TestQCUltra2Config:
     def test_has_device_info(self):
         assert qc_ultra2.DEVICE_INFO["name"] == "Bose QC Ultra Headphones 2"
         assert qc_ultra2.DEVICE_INFO["product_id"] == 0x4082
+
+    def test_qc_ultra2_earbuds_config(self):
+        assert qc_ultra2_earbuds.DEVICE_INFO["name"] == "Bose QuietComfort Ultra Earbuds (2nd Gen)"
+        assert qc_ultra2_earbuds.BATTERY_COMPONENTS == {1: "Right", 2: "Left", 3: "Case"}
 
     def test_has_all_features(self):
         expected = [

--- a/rust/src/catalog.rs
+++ b/rust/src/catalog.rs
@@ -54,7 +54,7 @@ pub const CATALOG: &[BoseDevice] = &[
     BoseDevice { product_id: 0x404C, codename: "celine_ii",  name: "Frames (2nd Gen)",                       category: Category::Earbuds, config: None },
     BoseDevice { product_id: 0x4060, codename: "olivia",     name: "Frames Tempo",                           category: Category::Earbuds, config: None },
     BoseDevice { product_id: 0x4061, codename: "vedder",     name: "Frames",                                 category: Category::Earbuds, config: None },
-    BoseDevice { product_id: 0x4062, codename: "edith",      name: "QuietComfort Ultra Earbuds (2nd Gen)",   category: Category::Earbuds, config: Some("qc_ultra2") },
+    BoseDevice { product_id: 0x4062, codename: "edith",      name: "QuietComfort Ultra Earbuds (2nd Gen)",   category: Category::Earbuds, config: Some("qc_ultra2_earbuds") },
     BoseDevice { product_id: 0x4064, codename: "smalls",     name: "QuietComfort Earbuds II",                category: Category::Earbuds, config: None },
     BoseDevice { product_id: 0x4068, codename: "serena",     name: "Ultra Open Earbuds",                     category: Category::Earbuds, config: Some("ultra_open") },
     BoseDevice { product_id: 0x4072, codename: "scotty",     name: "QuietComfort Ultra Earbuds",             category: Category::Earbuds, config: None },
@@ -130,7 +130,7 @@ mod tests {
     fn test_lookup_qc_ultra2_earbuds() {
         let dev = lookup_device(0x4062).unwrap();
         assert_eq!(dev.codename, "edith");
-        assert_eq!(dev.config, Some("qc_ultra2"));
+        assert_eq!(dev.config, Some("qc_ultra2_earbuds"));
     }
 
     #[test]

--- a/rust/src/connection.rs
+++ b/rust/src/connection.rs
@@ -37,8 +37,10 @@ impl<T: Transport> BmapConnection<T> {
     fn get(&self, addr: Addr) -> BmapResult<Vec<u8>> {
         let pkt = bmap_packet(addr.0, addr.1, Operator::Get, &[]);
         let data = self.transport.send_recv(&pkt)?;
-        let resp = parse_response(&data)
-            .ok_or_else(|| BmapError::Timeout("Empty response".into()))?;
+        let resp = parse_response(&data).ok_or_else(|| BmapError::Device {
+            message: "Invalid or empty response".into(),
+            code: 0,
+        })?;
         self.check_error(&resp)?;
         Ok(resp.payload)
     }
@@ -86,11 +88,49 @@ impl<T: Transport> BmapConnection<T> {
 
     /// Battery percentage.
     pub fn battery(&self) -> BmapResult<u8> {
+        Ok(self.battery_status()?.aggregate)
+    }
+
+    /// Aggregate and component levels from one battery response.
+    pub fn battery_status(&self) -> BmapResult<BatteryStatus> {
         let addr = self.addr(self.config.battery)?;
         let payload = self.get(addr)?;
-        parse_battery(&payload).ok_or_else(|| BmapError::Device {
-            message: "Empty battery response".into(), code: 0,
-        })
+        if let Some(component_id) = self.config.battery_aggregate_id {
+            let readings =
+                parse_battery_readings(&payload).map_err(|message| BmapError::Device {
+                    message: message.into(),
+                    code: 0,
+                })?;
+            let aggregate = readings
+                .iter()
+                .find(|reading| reading.component_id == component_id)
+                .map(|reading| reading.level)
+                .ok_or_else(|| BmapError::Device {
+                    message: format!(
+                        "Battery response missing aggregate component {}",
+                        component_id
+                    ),
+                    code: 0,
+                })?;
+            Ok(BatteryStatus {
+                aggregate,
+                readings,
+            })
+        } else {
+            let aggregate = parse_battery(&payload).ok_or_else(|| BmapError::Device {
+                message: "Empty battery response".into(),
+                code: 0,
+            })?;
+            Ok(BatteryStatus {
+                aggregate,
+                readings: Vec::new(),
+            })
+        }
+    }
+
+    /// Component battery readings, when the device reports multiple cells.
+    pub fn battery_readings(&self) -> BmapResult<Vec<BatteryReading>> {
+        Ok(self.battery_status()?.readings)
     }
 
     /// Firmware version string.
@@ -219,9 +259,11 @@ impl<T: Transport> BmapConnection<T> {
         };
         let (cnc_level, cnc_max) = self.cnc().unwrap_or((0, 10));
         let (prompts_enabled, prompts_language) = self.prompts().unwrap_or((false, "Unknown"));
+        let battery = self.battery_status()?;
 
         Ok(DeviceStatus {
-            battery: self.battery()?,
+            battery: battery.aggregate,
+            battery_readings: battery.readings,
             mode: current_name,
             mode_idx: current_idx,
             cnc_level,
@@ -675,6 +717,76 @@ mod tests {
     }
 
     #[test]
+    fn test_battery_rejects_empty_response() {
+        let mut t = MockTransport::new();
+        t.add(2, 2, 0x03, &[]);
+        let dev = BmapConnection::new(t, devices::qc_ultra2());
+        assert!(matches!(dev.battery(), Err(BmapError::Device { message, .. })
+            if message.contains("Empty battery response")));
+    }
+
+    #[test]
+    fn test_battery_rejects_invalid_frame() {
+        let mut t = MockTransport::new();
+        t.responses.insert((2, 2), vec![2, 2, 0x08, 0]);
+        let dev = BmapConnection::new(t, devices::qc_ultra2());
+        assert!(matches!(dev.battery(), Err(BmapError::Device { message, .. })
+            if message.contains("Invalid or empty response")));
+    }
+
+    #[test]
+    fn test_battery_readings() {
+        let mut t = MockTransport::new();
+        t.add(2, 2, 0x03, &[
+            0x50,0xff,0xff,0x03, 0x3c,0xff,0xff,0x01,
+            0x3c,0xff,0xff,0x02, 0x46,0xff,0xff,0x04,
+        ]);
+        let dev = BmapConnection::new(t, devices::qc_ultra2_earbuds());
+        let battery = dev.battery_status().unwrap();
+        assert_eq!(battery.readings, vec![
+            BatteryReading { component_id: 3, level: 80 },
+            BatteryReading { component_id: 1, level: 60 },
+            BatteryReading { component_id: 2, level: 60 },
+            BatteryReading { component_id: 4, level: 70 },
+        ]);
+        assert_eq!(battery.aggregate, 70);
+        assert_eq!(dev.transport.sent.borrow().len(), 1);
+    }
+
+    #[test]
+    fn test_battery_rejects_missing_aggregate_component() {
+        let mut t = MockTransport::new();
+        t.add(2, 2, 0x03, &[
+            0x3c,0xff,0xff,0x01, 0x3c,0xff,0xff,0x02,
+            0x50,0xff,0xff,0x03,
+        ]);
+        let dev = BmapConnection::new(t, devices::qc_ultra2_earbuds());
+        assert!(matches!(dev.battery(), Err(BmapError::Device { message, .. })
+            if message.contains("aggregate component 4")));
+    }
+
+    #[test]
+    fn test_status_uses_one_battery_response() {
+        let mut t = MockTransport::new();
+        t.add(2, 2, 0x03, &[
+            0x50,0xff,0xff,0x03, 0x3c,0xff,0xff,0x01,
+            0x46,0xff,0xff,0x04, 0x3c,0xff,0xff,0x02,
+        ]);
+        let dev = BmapConnection::new(t, devices::qc_ultra2_earbuds());
+        let status = dev.status().unwrap();
+        assert_eq!(status.battery, 70);
+        assert_eq!(status.battery_readings.len(), 4);
+        let battery_requests = dev
+            .transport
+            .sent
+            .borrow()
+            .iter()
+            .filter(|packet| packet.starts_with(&[2, 2]))
+            .count();
+        assert_eq!(battery_requests, 1);
+    }
+
+    #[test]
     fn test_firmware() {
         assert_eq!(mock_qc_ultra2().firmware().unwrap(), "8.2.20+g34cf029");
     }
@@ -738,6 +850,7 @@ mod tests {
     fn test_status() {
         let s = mock_qc_ultra2().status().unwrap();
         assert_eq!(s.battery, 80);
+        assert!(s.battery_readings.is_empty());
         assert_eq!(s.mode, "quiet");
         assert_eq!(s.cnc_level, 7);
         assert_eq!(s.cnc_max, 10);

--- a/rust/src/device.rs
+++ b/rust/src/device.rs
@@ -60,6 +60,20 @@ pub struct ButtonMapping {
     pub action_name: &'static str,
 }
 
+/// A component battery reading from a device with multiple cells.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BatteryReading {
+    pub component_id: u8,
+    pub level: u8,
+}
+
+/// Aggregate and component levels parsed from one battery response.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BatteryStatus {
+    pub aggregate: u8,
+    pub readings: Vec<BatteryReading>,
+}
+
 /// Audio source information.
 #[derive(Debug, Clone)]
 pub struct AudioSource {
@@ -71,6 +85,7 @@ pub struct AudioSource {
 #[derive(Debug, Clone)]
 pub struct DeviceStatus {
     pub battery: u8,
+    pub battery_readings: Vec<BatteryReading>,
     pub mode: String,
     pub mode_idx: u8,
     pub cnc_level: u8,
@@ -94,6 +109,10 @@ pub struct DeviceConfig {
     /// Init packet required before device responds (Some((fblock, func)) for QC35).
     pub init_packet: Option<Addr>,
     pub battery: Option<Addr>,
+    /// Component IDs and display labels for multi-cell battery responses.
+    pub battery_components: &'static [(u8, &'static str)],
+    /// Component ID used for the generic aggregate battery value.
+    pub battery_aggregate_id: Option<u8>,
     pub firmware: Option<Addr>,
     pub product_name: Option<Addr>,
     pub voice_prompts: Option<Addr>,
@@ -133,6 +152,29 @@ pub struct DeviceConfig {
 
 pub fn parse_battery(payload: &[u8]) -> Option<u8> {
     payload.first().copied()
+}
+
+/// Parse four-byte component battery records from [2.2].
+pub fn parse_battery_readings(payload: &[u8]) -> Result<Vec<BatteryReading>, &'static str> {
+    if payload.len() % 4 != 0 {
+        return Err("Malformed battery response");
+    }
+    let mut readings = Vec::new();
+    let mut seen_components = Vec::new();
+    for record in payload.chunks_exact(4) {
+        let component_id = record[3];
+        if seen_components.contains(&component_id) {
+            return Err("Duplicate battery component");
+        }
+        seen_components.push(component_id);
+        if record[0] <= 100 {
+            readings.push(BatteryReading {
+                component_id,
+                level: record[0],
+            });
+        }
+    }
+    Ok(readings)
 }
 
 pub fn parse_firmware(payload: &[u8]) -> String {
@@ -587,10 +629,68 @@ pub fn build_mode_config_39(
 mod tests {
     use super::*;
 
+    fn decode_hex(text: &str) -> Vec<u8> {
+        let text = text.trim();
+        (0..text.len())
+            .step_by(2)
+            .map(|i| u8::from_str_radix(&text[i..i + 2], 16).unwrap())
+            .collect()
+    }
+
     #[test]
     fn test_parse_battery() {
         assert_eq!(parse_battery(&[0x50, 0xff, 0xff, 0x00]), Some(0x50));
         assert_eq!(parse_battery(&[]), None);
+    }
+
+    #[test]
+    fn test_parse_battery_readings() {
+        let payload = decode_hex(include_str!(
+            "../../fixtures/packets/qc-ultra2-earbuds/battery-status.hex"
+        ));
+        assert_eq!(
+            parse_battery_readings(&payload).unwrap(),
+            vec![
+                BatteryReading {
+                    component_id: 1,
+                    level: 60
+                },
+                BatteryReading {
+                    component_id: 2,
+                    level: 60
+                },
+                BatteryReading {
+                    component_id: 4,
+                    level: 60
+                },
+                BatteryReading {
+                    component_id: 3,
+                    level: 80
+                },
+            ]
+        );
+        assert_eq!(
+            parse_battery_readings(&[
+                0x50,0xff,0xff,0x03, 0x46,0xff,0xff,0x04,
+                0x32,0xff,0xff,0x09, 0x3c,0xff,0xff,0x01,
+                0x3c,0xff,0xff,0x02,
+            ])
+            .unwrap()
+            .iter()
+            .map(|reading| reading.component_id)
+            .collect::<Vec<_>>(),
+            vec![3, 4, 9, 1, 2],
+        );
+        assert_eq!(
+            parse_battery_readings(&[0x50, 0xff]),
+            Err("Malformed battery response"),
+        );
+        assert_eq!(
+            parse_battery_readings(&[
+                0x3c, 0xff, 0xff, 0x01, 0x50, 0xff, 0xff, 0x01,
+            ]),
+            Err("Duplicate battery component"),
+        );
     }
 
     #[test]

--- a/rust/src/devices.rs
+++ b/rust/src/devices.rs
@@ -17,6 +17,8 @@ pub fn qc_ultra2() -> DeviceConfig {
         rfcomm_channel: 2,
         init_packet: None,
         battery: Some(Addr(2, 2)),
+        battery_components: &[],
+        battery_aggregate_id: None,
         firmware: Some(Addr(0, 5)),
         product_name: Some(Addr(1, 2)),
         voice_prompts: Some(Addr(1, 3)),
@@ -51,6 +53,20 @@ pub fn qc_ultra2() -> DeviceConfig {
     }
 }
 
+/// Bose QuietComfort Ultra Earbuds 2 configuration -- edith, product ID 0x4062.
+/// Shares the QC Ultra 2 protocol layout and reports separate battery cells.
+pub fn qc_ultra2_earbuds() -> DeviceConfig {
+    let mut c = qc_ultra2();
+    c.info = DeviceInfo {
+        name: "Bose QuietComfort Ultra Earbuds (2nd Gen)",
+        codename: "edith",
+        platform: "OTG-QCC-384",
+    };
+    c.battery_components = &[(1, "Right"), (2, "Left"), (3, "Case")];
+    c.battery_aggregate_id = Some(4);
+    c
+}
+
 /// Bose QuietComfort Headphones configuration -- prince, product ID 0x4075.
 /// Verified against firmware 1.0.6-80+f5f219b.
 /// BMAP over RFCOMM channel 8 with 47-byte ModeConfig STATUS responses.
@@ -64,6 +80,8 @@ pub fn qc_prince() -> DeviceConfig {
         rfcomm_channel: 8,
         init_packet: None,
         battery: Some(Addr(2, 2)),
+        battery_components: &[],
+        battery_aggregate_id: None,
         firmware: Some(Addr(0, 5)),
         product_name: Some(Addr(1, 2)),
         voice_prompts: Some(Addr(1, 3)),
@@ -110,6 +128,8 @@ pub fn qc35() -> DeviceConfig {
         rfcomm_channel: 8,
         init_packet: Some(Addr(0, 1)),  // GET [0.1] required before QC35 responds
         battery: Some(Addr(2, 2)),
+        battery_components: &[],
+        battery_aggregate_id: None,
         firmware: Some(Addr(0, 5)),
         product_name: Some(Addr(1, 2)),
         voice_prompts: Some(Addr(1, 3)),
@@ -157,6 +177,8 @@ pub fn qc_earbuds() -> DeviceConfig {
         rfcomm_channel: 8,
         init_packet: None,
         battery: Some(Addr(2, 2)),
+        battery_components: &[],
+        battery_aggregate_id: None,
         firmware: Some(Addr(0, 5)),
         product_name: Some(Addr(1, 2)),
         voice_prompts: Some(Addr(1, 3)),
@@ -202,6 +224,8 @@ pub fn qc45() -> DeviceConfig {
         rfcomm_channel: 8,
         init_packet: Some(Addr(0, 1)),
         battery: Some(Addr(2, 2)),
+        battery_components: &[],
+        battery_aggregate_id: None,
         firmware: Some(Addr(0, 5)),
         product_name: Some(Addr(1, 2)),
         voice_prompts: Some(Addr(1, 3)),
@@ -248,6 +272,8 @@ pub fn ultra_open() -> DeviceConfig {
         rfcomm_channel: 2,
         init_packet: None,
         battery: Some(Addr(2, 2)),
+        battery_components: &[],
+        battery_aggregate_id: None,
         firmware: Some(Addr(0, 5)),
         product_name: Some(Addr(1, 2)),
         voice_prompts: Some(Addr(1, 3)),
@@ -280,6 +306,7 @@ pub fn ultra_open() -> DeviceConfig {
 pub fn get_device(name: &str) -> Option<DeviceConfig> {
     match name {
         "qc_ultra2" => Some(qc_ultra2()),
+        "qc_ultra2_earbuds" => Some(qc_ultra2_earbuds()),
         "qc35" => Some(qc35()),
         "qc_prince" => Some(qc_prince()),
         "qc_earbuds" => Some(qc_earbuds()),
@@ -326,12 +353,23 @@ mod tests {
     #[test]
     fn test_get_device() {
         assert!(get_device("qc_ultra2").is_some());
+        assert!(get_device("qc_ultra2_earbuds").is_some());
         assert!(get_device("qc35").is_some());
         assert!(get_device("qc_prince").is_some());
         assert!(get_device("qc_earbuds").is_some());
         assert!(get_device("qc45").is_some());
         assert!(get_device("ultra_open").is_some());
         assert!(get_device("nonexistent").is_none());
+    }
+
+    #[test]
+    fn test_qc_ultra2_earbuds_identity_and_battery_components() {
+        let dev = qc_ultra2_earbuds();
+        assert_eq!(dev.info.codename, "edith");
+        assert_eq!(dev.battery_components, &[(1, "Right"), (2, "Left"), (3, "Case")]);
+        assert_eq!(dev.battery_aggregate_id, Some(4));
+        assert_eq!(dev.preset_modes.len(), 4);
+        assert!(dev.audio_settings.is_some());
     }
 
     #[test]

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -22,17 +22,27 @@ pub mod catalog;
 
 pub use connection::BmapConnection;
 pub use transport::Transport;
-pub use device::{DeviceConfig, DeviceStatus, ModeConfig, EqBand, ButtonMapping};
+pub use device::{
+    BatteryReading, BatteryStatus, ButtonMapping, DeviceConfig, DeviceStatus,
+    EqBand, ModeConfig,
+};
 pub use error::{BmapError, BmapResult};
 pub use protocol::{Operator, BmapResponse};
 
 /// Connect to a BMAP device over Bluetooth RFCOMM.
 ///
 /// - `mac`: Bluetooth MAC address. Auto-detected if None.
-/// - `device_type`: Device type string. Auto-detected if None.
+/// - `device_type`: Device type string. Auto-detected only when `mac` is None.
 pub fn connect(mac: Option<&str>, device_type: Option<&str>) -> BmapResult<BmapConnection<transport::RfcommTransport>> {
+    let mac = mac.filter(|value| !value.is_empty());
+    let device_type = device_type.filter(|value| !value.is_empty());
     let (mac, resolved_type) = match mac {
-        Some(m) => (m.to_string(), device_type.unwrap_or("qc_ultra2").to_string()),
+        Some(m) => {
+            let dtype = device_type.ok_or_else(|| BmapError::InvalidArg(
+                "device_type is required when mac is specified".into()
+            ))?;
+            (m.to_string(), dtype.to_string())
+        }
         None => {
             let (detected_mac, detected_type) = discovery::find_bmap_device()
                 .ok_or_else(|| BmapError::NotFound(
@@ -48,6 +58,20 @@ pub fn connect(mac: Option<&str>, device_type: Option<&str>) -> BmapResult<BmapC
 
     let transport = open_transport(&mac, config.rfcomm_channel, config.init_packet)?;
     Ok(BmapConnection::new(transport, config))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn explicit_mac_requires_device_type() {
+        for device_type in [None, Some("")] {
+            let result = connect(Some("00:11:22:33:44:55"), device_type);
+            assert!(matches!(result, Err(BmapError::InvalidArg(message))
+                if message.contains("device_type is required")));
+        }
+    }
 }
 
 /// RFCOMM channels BMAP has been observed on. The channel a unit exposes can

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -266,6 +266,15 @@ fn cmd_status(dev: &bmap::BmapConnection<impl bmap::Transport>) -> Result<(), Bm
 
     println!("  Model        {}", dev.config().info.name);
     println!("  Battery      {}%", s.battery);
+    for (component_id, label) in dev.config().battery_components {
+        if let Some(reading) = s
+            .battery_readings
+            .iter()
+            .find(|reading| reading.component_id == *component_id)
+        {
+            println!("  {:12} {}%", label, reading.level);
+        }
+    }
     if !s.mode.is_empty() {
         println!("  Mode         {}", s.mode);
     }
@@ -326,5 +335,5 @@ fn usage() {
     println!();
     println!("Environment:");
     println!("  BMAP_MAC=XX:XX:XX:XX:XX:XX   Device MAC (auto-detected if unset)");
-    println!("  BMAP_DEVICE=qc_ultra2|qc_prince|qc35   Device type");
+    println!("  BMAP_DEVICE=qc_ultra2|qc_ultra2_earbuds|qc_prince|qc35|qc_earbuds|qc45|ultra_open");
 }

--- a/rust/src/protocol.rs
+++ b/rust/src/protocol.rs
@@ -113,8 +113,10 @@ pub fn parse_response(data: &[u8]) -> Option<BmapResponse> {
     let func = data[1];
     let op = Operator::from_u8(data[2])?;
     let length = data[3] as usize;
-    let end = std::cmp::min(4 + length, data.len());
-    let payload = data[4..end].to_vec();
+    if data.len() < 4 + length {
+        return None;
+    }
+    let payload = data[4..4 + length].to_vec();
     Some(BmapResponse { fblock, func, op, payload })
 }
 
@@ -178,6 +180,8 @@ mod tests {
     #[test]
     fn test_parse_response_too_short() {
         assert!(parse_response(&[1, 2]).is_none());
+        assert!(parse_response(&[2, 2, 0x03, 4, 80, 0xff]).is_none());
+        assert!(parse_response(&[2, 2, 0x08, 0]).is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add QC Ultra 2 Earbuds (2nd Gen) support for product `0x4062` / `edith`.
- Report separate Right, Left, and Case battery levels from BMAP `[2.2]`.
- Use component ID `4` for the generic aggregate battery value.

## Changes

- Add device catalog entries and configurations in Python, Rust, and C++.
- Parse battery records by component ID instead of payload position.
- Keep `[2.5]` classified as earbud seating state, not charging state.
- Update CLI output, launcher behavior, protocol notes, and architecture documentation.
- Add regression tests for component ordering and aggregate battery selection.

## Device Impact

- [x] New device: QC Ultra 2 Earbuds (2nd Gen), product `0x4062`

Hardware validation is complete against physical QC Ultra 2 Earbuds (2nd Gen / edith) hardware. The automated suite uses captured fixtures and mock transports.

## Checklist

- [x] Python, Rust, and C++ implementations stay in sync
- [x] Tests pass (`make test`)
- [x] Protocol notes updated in NOTES.md (if applicable)
- [x] Architecture docs updated (if applicable)

🤖 Generated with GPT-5.6 Luna (xhigh)